### PR TITLE
Update go to use mise for version management

### DIFF
--- a/fish/conf.d/02-tools.fish
+++ b/fish/conf.d/02-tools.fish
@@ -60,15 +60,6 @@ else if test -d /home/linuxbrew/.linuxbrew
     eval (/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 end
 
-# Go lazy PATH addition
-function go
-    if not set -q GO_ADDED
-        fish_add_path (command go env GOPATH)/bin
-        set -gx GO_ADDED 1
-    end
-    command go $argv
-end
-
 # Rbenv - lazy load with official init
 if test -d $HOME/.rbenv
     function rbenv

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -1,7 +1,3 @@
-[tools]
-bun = "latest"
-go = "latest"
-node = "latest"
 
 [settings]
-idiomatic_version_file_enable_tools = ["node"]
+idiomatic_version_file_enable_tools = ["node", "go"]

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -2,6 +2,17 @@ return {
   "neovim/nvim-lspconfig",
   opts = {
     servers = {
+      bashls = {
+        handlers = {
+          ["textDocument/publishDiagnostics"] = function(err, res, ...)
+            local file_name = vim.fn.fnamemodify(vim.uri_to_fname(res.uri), ":t")
+            if string.match(file_name, "^%.env.*") then
+              return
+            end
+            vim.lsp.diagnostic.on_publish_diagnostics(err, res, ...)
+          end,
+        },
+      },
       harper_ls = {
         filetypes = { "markdown", "text" },
         on_init = function(client, _)

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -5,11 +5,17 @@ return {
       bashls = {
         handlers = {
           ["textDocument/publishDiagnostics"] = function(err, res, ...)
+            -- Fallback to default handler if the payload is missing or malformed
+            if err or not res or not res.uri then
+              return vim.lsp.diagnostic.on_publish_diagnostics(err, res, ...)
+            end
+
             local file_name = vim.fn.fnamemodify(vim.uri_to_fname(res.uri), ":t")
             if string.match(file_name, "^%.env.*") then
               return
             end
-            vim.lsp.diagnostic.on_publish_diagnostics(err, res, ...)
+
+            return vim.lsp.diagnostic.on_publish_diagnostics(err, res, ...)
           end,
         },
       },


### PR DESCRIPTION
Remove manual go PATH handling from fish shell configuration and consolidate tool version management through mise.

**Changes:**
- Remove the custom `go` function wrapper that manually adds GOPATH/bin to PATH
- Remove go, bun, and node from explicit tools list in mise config (now managed via idiomatic version files)
- Add go to idiomatic version file detection in mise settings for automatic tooling

**Rationale:**
Mise now handles go version detection and PATH management directly, eliminating the need for manual shell functions. This simplifies the configuration and reduces duplication between fish setup and mise.
```
