### PR TITLE
fix(nvim): update Catppuccin colorscheme configuration

### DIFF
--- a/nvim/lua/plugins/colorscheme.lua
+++ b/nvim/lua/plugins/colorscheme.lua
@@ -4,7 +4,7 @@ return {
     name = "catppuccin",
     priority = 1000,
     opts = {
-      flavour = "mocha",
+      flavour = "macchiato",
       transparent_background = true,
       custom_highlights = function(colors)
         return {
@@ -41,7 +41,7 @@ return {
   {
     "LazyVim/LazyVim",
     opts = {
-      colorscheme = "catppuccin",
+      colorscheme = "catppuccin-nvim",
     },
   },
 }


### PR DESCRIPTION
Update Catppuccin theme configuration to use `macchiato` flavor instead of `mocha` and correct the colorscheme name to `catppuccin-nvim`. This resolves theme loading issues and ensures consistency with the installed colorscheme plugin.
