### PR TITLE
fix(fish): fix jj workspace jump for existing workspaces

### DIFF
--- a/fish/functions/_jj_workspace_jump.fish
+++ b/fish/functions/_jj_workspace_jump.fish
@@ -23,13 +23,31 @@ function _jj_workspace_jump --argument-names suffix
 
     set -l original_dir "$PWD"
 
-    if not test -d $target_dir
-        jj workspace add $target_dir
+    if not test -d "$target_dir"
+        jj workspace add "$target_dir"
         or return 1
-        cd $target_dir
+        cd "$target_dir"
+        or begin
+            if set -q TMUX
+                cd "$original_dir"
+            end
+            return 1
+        end
         jj new $change_id
+        or begin
+            if set -q TMUX
+                cd "$original_dir"
+            end
+            return 1
+        end
     else
-        cd $target_dir
+        cd "$target_dir"
+        or begin
+            if set -q TMUX
+                cd "$original_dir"
+            end
+            return 1
+        end
         jj workspace update-stale 2>/dev/null
         jj new $change_id
         or begin
@@ -45,10 +63,11 @@ function _jj_workspace_jump --argument-names suffix
 
     if set -q TMUX
         cd "$original_dir"
-        tmux new-window -c $target_dir -n $suffix -e "GIT_DIR=$git_dir" "mise trust 2>/dev/null; $SHELL"
+        tmux new-window -c "$target_dir" -n $suffix -e "GIT_DIR=$git_dir" "mise trust 2>/dev/null; $SHELL"
     else
         set -x GIT_DIR $git_dir
-        cd $target_dir
+        cd "$target_dir"
+        or return 1
         mise trust 2>/dev/null
     end
 end

--- a/fish/functions/_jj_workspace_jump.fish
+++ b/fish/functions/_jj_workspace_jump.fish
@@ -15,6 +15,17 @@ function _jj_workspace_jump --argument-names suffix
 
     set -l main_root (dirname $root)/$base
     set -l target_dir $main_root-$suffix
+    set -l git_dir "$main_root/.git"
+    set -l has_git_dir false
+    set -l supports_update_stale false
+
+    if test -e "$git_dir"
+        set has_git_dir true
+    end
+
+    if jj workspace update-stale --help >/dev/null 2>&1
+        set supports_update_stale true
+    end
 
     if test "$target_dir" = "$root"
         echo "Already in $suffix workspace" >&2
@@ -48,7 +59,17 @@ function _jj_workspace_jump --argument-names suffix
             end
             return 1
         end
-        jj workspace update-stale 2>/dev/null
+
+        if test "$supports_update_stale" = true
+            jj workspace update-stale
+            or begin
+                if set -q TMUX
+                    cd "$original_dir"
+                end
+                return 1
+            end
+        end
+
         jj new $change_id
         or begin
             if set -q TMUX
@@ -59,15 +80,19 @@ function _jj_workspace_jump --argument-names suffix
     end
 
     # Point git tools (gh, etc.) at the main repo's .git so they work from workspaces
-    set -l git_dir "$main_root/.git"
-
     if set -q TMUX
         cd "$original_dir"
-        tmux new-window -c "$target_dir" -n $suffix -e "GIT_DIR=$git_dir" "mise trust 2>/dev/null; $SHELL"
+        set -l tmux_args new-window -c "$target_dir" -n $suffix
+        if test "$has_git_dir" = true
+            set tmux_args $tmux_args -e "GIT_DIR=$git_dir"
+        end
+        tmux $tmux_args "mise trust 2>/dev/null; $SHELL"
     else
-        set -x GIT_DIR $git_dir
         cd "$target_dir"
         or return 1
+        if test "$has_git_dir" = true
+            set -x GIT_DIR $git_dir
+        end
         mise trust 2>/dev/null
     end
 end

--- a/fish/functions/_jj_workspace_jump.fish
+++ b/fish/functions/_jj_workspace_jump.fish
@@ -13,7 +13,8 @@ function _jj_workspace_jump --argument-names suffix
         set base (string replace -r -- "$workspace_suffix_re" '' $base)
     end
 
-    set -l target_dir (dirname $root)/$base-$suffix
+    set -l main_root (dirname $root)/$base
+    set -l target_dir $main_root-$suffix
 
     if test "$target_dir" = "$root"
         echo "Already in $suffix workspace" >&2
@@ -23,11 +24,14 @@ function _jj_workspace_jump --argument-names suffix
     set -l original_dir "$PWD"
 
     if not test -d $target_dir
-        jj workspace add $target_dir -r @
+        jj workspace add $target_dir
         or return 1
+        cd $target_dir
+        jj new $change_id
     else
         cd $target_dir
-        jj edit $change_id
+        jj workspace update-stale 2>/dev/null
+        jj new $change_id
         or begin
             if set -q TMUX
                 cd "$original_dir"
@@ -36,10 +40,14 @@ function _jj_workspace_jump --argument-names suffix
         end
     end
 
+    # Point git tools (gh, etc.) at the main repo's .git so they work from workspaces
+    set -l git_dir "$main_root/.git"
+
     if set -q TMUX
         cd "$original_dir"
-        tmux new-window -c $target_dir -n $suffix "mise trust 2>/dev/null; $SHELL"
+        tmux new-window -c $target_dir -n $suffix -e "GIT_DIR=$git_dir" "mise trust 2>/dev/null; $SHELL"
     else
+        set -x GIT_DIR $git_dir
         cd $target_dir
         mise trust 2>/dev/null
     end


### PR DESCRIPTION
## Summary
- Add `jj workspace update-stale` before editing to handle stale workspaces when the directory already exists
- Use `jj new` instead of `jj edit` so each workspace gets its own child change rather than concurrent edits to the same revision

## Test plan
- [ ] Run `ai1` from a jj repo to create a new workspace — should work as before
- [ ] Run `ai1` again when workspace already exists — should succeed without stale errors
- [ ] Verify `jj log` shows distinct changes in each workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)