### PR TITLE
use big pickle (free) instead of claude for ghpr at home

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(jj log *)"
+    ]
+  }
+}

--- a/.stowrc
+++ b/.stowrc
@@ -13,4 +13,5 @@
 --ignore=ai
 --ignore=resources
 --ignore=^\.env$
+--ignore=^\.claude$
 --ignore=starship

--- a/fish/conf.d/ai_helpers.fish
+++ b/fish/conf.d/ai_helpers.fish
@@ -1,0 +1,67 @@
+# Shared helpers for opencode-backed commit/PR message generation.
+# Consumed by `ghpr` and `commit`. Private — underscore prefix.
+
+function _ai_model --description "Pick opencode model per platform"
+    if test (uname -s) = Darwin
+        echo openai/gpt-4o-mini
+    else
+        echo opencode/big-pickle
+    end
+end
+
+function _ai_run --description "Invoke opencode outside a pipeline so \$status survives" \
+    --argument-names model prompt_file out_file err_file
+    # Fish collapses \$pipestatus to a single element across command substitution,
+    # so piping into opencode loses the real exit code. Explicit file redirects
+    # keep status intact for the caller.
+    opencode run --model $model --format default <$prompt_file >$out_file 2>$err_file
+end
+
+function _ai_strip_fences --description "Drop leading ``` fence line + matching trailing ``` line"
+    # Reads stdin, writes to stdout. Only outermost fences are stripped;
+    # internal ``` blocks in message bodies are preserved.
+    awk '
+        NR == 1 && /^```/ { next }
+        { buf[NR] = $0 }
+        END {
+            end = NR
+            if (end in buf && buf[end] ~ /^```[[:space:]]*$/) end--
+            for (i = 1; i <= end; i++) if (i in buf) print buf[i]
+        }'
+end
+
+function _ai_strip_trailer --description "Truncate output at model pleasantry lines"
+    # Reads stdin, stops at lines like "Feel free to modify..." — models emit
+    # these despite instructions to the contrary. Pattern is lowercase-matched
+    # (BSD awk has no IGNORECASE) but the original line would have been dropped
+    # anyway, so casing of the input doesn't matter.
+    awk '
+        tolower($0) ~ /^(feel free to |let me know if |hope (this|that) helps|if you (need|have)|please (let me|note)|you can (modify|customize|adjust))/ { exit }
+        { print }'
+end
+
+function _ai_extract_marker --description "Pull TITLE or BODY section from formatted AI output" \
+    --argument-names marker file
+    # Tolerates markdown-decorated markers (### TITLE:, **BODY:**) by stripping
+    # leading # * whitespace *only when probing* — body content is printed
+    # verbatim so its own markdown survives.
+    awk -v marker="$marker" '
+        started == 2 { print; next }
+        {
+            probe = $0
+            sub(/^[[:space:]#*]+/, "", probe)
+            sub(/[[:space:]*]+$/, "", probe)
+            if (started == 0 && match(probe, "^" marker ":[[:space:]]*")) {
+                rest = substr(probe, RLENGTH + 1)
+                if (marker == "TITLE") {
+                    if (length(rest) > 0) { print rest; exit }
+                    want = 1
+                } else {
+                    started = 2
+                    if (length(rest) > 0) print rest
+                }
+                next
+            }
+            if (marker == "TITLE" && want && length(probe) > 0) { print probe; exit }
+        }' $file
+end

--- a/fish/conf.d/ai_helpers.fish
+++ b/fish/conf.d/ai_helpers.fish
@@ -62,6 +62,12 @@ function _ai_extract_marker --description "Pull TITLE or BODY section from forma
                 }
                 next
             }
-            if (marker == "TITLE" && want && length(probe) > 0) { print probe; exit }
+            # Guard: if the next non-empty line is itself a marker (BODY:/TITLE:),
+            # the model left TITLE empty. Exit without printing so the caller
+            # fallback title logic can fire instead of capturing BODY as title.
+            if (marker == "TITLE" && want && length(probe) > 0) {
+                if (probe ~ /^(TITLE|BODY):/) exit
+                print probe; exit
+            }
         }' $file
 end

--- a/fish/functions/commit.fish
+++ b/fish/functions/commit.fish
@@ -11,7 +11,8 @@ function commit --description "AI-generated commit message"
 
     set -l custom_message ""
     if set -q _flag_message
-        set custom_message $_flag_message
+        # argparse collects repeated -m into a list; take the last value (git-like semantics).
+        set custom_message $_flag_message[-1]
     end
 
     # Detect VCS

--- a/fish/functions/commit.fish
+++ b/fish/functions/commit.fish
@@ -46,11 +46,6 @@ function commit --description "AI-generated commit message"
     if test -n "$custom_message"
         set commit_message $custom_message
     else if type -q opencode
-        set -l oc_model opencode/big-pickle
-        if test (uname -s) = Darwin
-            set oc_model openai/gpt-4o-mini
-        end
-
         echo "✓ Generating commit message..."
 
         set -l max_diff_bytes 20000
@@ -72,12 +67,27 @@ Rules:
 - Scope is optional — omit unless changes are clearly scoped to one area
 - Subject line: imperative mood, max 72 chars, no period
 - No body unless the change genuinely needs explanation
-- Output ONLY the commit message, nothing else
+- Output ONLY the commit message, nothing else. No code fences, no preamble.
 
 ## Diff
 $truncated_diff"
 
-        set commit_message (printf "%s" $prompt | opencode run --model $oc_model --format default 2>/dev/null | string trim | string collect)
+        set -l oc_in (mktemp)
+        set -l oc_out (mktemp)
+        set -l oc_err (mktemp)
+        printf "%s" $prompt >$oc_in
+        _ai_run (_ai_model) $oc_in $oc_out $oc_err
+        set -l oc_status $status
+        set -l raw (string collect <$oc_out)
+        set -l err_text (string collect <$oc_err)
+        rm -f $oc_in $oc_out $oc_err
+
+        if test $oc_status -ne 0
+            echo "⚠ opencode exit=$oc_status"
+            test -n "$err_text"; and printf "%s\n" $err_text | string replace -r '^' '   '
+        end
+
+        set commit_message (printf "%s" $raw | _ai_strip_fences | string trim | string collect)
     end
 
     if test -z "$commit_message"

--- a/fish/functions/commit.fish
+++ b/fish/functions/commit.fish
@@ -1,0 +1,142 @@
+# AI-generated commit message using opencode, then commits via git or jj
+
+function commit --description "AI-generated commit message"
+    argparse d/dry-run 'm/message=' -- $argv
+    or return 1
+
+    set -l dry_run false
+    if set -q _flag_dry_run
+        set dry_run true
+    end
+
+    set -l custom_message ""
+    if set -q _flag_message
+        set custom_message $_flag_message
+    end
+
+    # Detect VCS
+    set -l is_jj false
+    if type -q jj; and jj workspace root >/dev/null 2>&1
+        set is_jj true
+    else if not type -q git; or not git rev-parse --git-dir >/dev/null 2>&1
+        echo "Error: Not in a git or jj repository"
+        return 1
+    end
+
+    # Gather diff
+    set -l diff_content ""
+    if test "$is_jj" = true
+        set diff_content (jj diff 2>/dev/null | string collect)
+    else
+        set diff_content (git diff --staged 2>/dev/null | string collect)
+    end
+
+    if test -z "$diff_content"
+        if test "$is_jj" = true
+            echo "Error: No changes in working copy"
+        else
+            echo "Error: No staged changes. Stage files with: git add <files>"
+        end
+        return 1
+    end
+
+    # Generate message
+    set -l commit_message ""
+
+    if test -n "$custom_message"
+        set commit_message $custom_message
+    else if type -q opencode
+        set -l oc_model opencode/big-pickle
+        if test (uname -s) = Darwin
+            set oc_model openai/gpt-4o-mini
+        end
+
+        echo "✓ Generating commit message..."
+
+        set -l max_diff_bytes 20000
+        set -l truncated_diff $diff_content
+        if test -n "$diff_content"
+            set -l diff_bytes (printf "%s" "$diff_content" | wc -c | string trim)
+            if test "$diff_bytes" -gt "$max_diff_bytes"
+                set truncated_diff (printf "%s" "$diff_content" | head -c $max_diff_bytes | string collect)
+                set truncated_diff "$truncated_diff
+
+[... diff truncated ...]"
+            end
+        end
+
+        set -l prompt "Generate a git commit message for these changes.
+
+Rules:
+- Conventional commit format: <type>(<scope>): <description>
+- Scope is optional — omit unless changes are clearly scoped to one area
+- Subject line: imperative mood, max 72 chars, no period
+- No body unless the change genuinely needs explanation
+- Output ONLY the commit message, nothing else
+
+## Diff
+$truncated_diff"
+
+        set commit_message (printf "%s" $prompt | opencode run --model $oc_model --format default 2>/dev/null | string trim | string collect)
+    end
+
+    if test -z "$commit_message"
+        echo "Error: Failed to generate commit message"
+        return 1
+    end
+
+    # Preview
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "Commit message:"
+    echo "────────────────────────────────────────────────────"
+    printf "%s\n" $commit_message
+    echo "────────────────────────────────────────────────────"
+    echo ""
+
+    if test "$dry_run" = true
+        echo "Dry run — no commit created"
+        return 0
+    end
+
+    # Confirm with edit option
+    while true
+        read -P "Commit? [Y/n/e(dit)]: " -l confirm
+        switch $confirm
+            case "" Y y
+                break
+            case e E
+                set -l temp_file (mktemp)
+                printf "%s\n" $commit_message >$temp_file
+
+                set -l editor_cmd
+                if test -n "$VISUAL"
+                    set editor_cmd (string split ' ' -- $VISUAL)
+                else if test -n "$EDITOR"
+                    set editor_cmd (string split ' ' -- $EDITOR)
+                else
+                    set editor_cmd vim
+                end
+
+                $editor_cmd -- $temp_file
+                set commit_message (string trim (string collect <$temp_file))
+                rm $temp_file
+
+                echo ""
+                echo "────────────────────────────────────────────────────"
+                printf "%s\n" $commit_message
+                echo "────────────────────────────────────────────────────"
+                echo ""
+            case '*'
+                echo "Cancelled."
+                return 0
+        end
+    end
+
+    # Commit
+    if test "$is_jj" = true
+        jj commit -m "$commit_message"
+    else
+        git commit -m "$commit_message"
+    end
+end

--- a/fish/functions/ghpr.fish
+++ b/fish/functions/ghpr.fish
@@ -6,12 +6,12 @@ function ghpr --description "Create GitHub PR with conventional commit format"
     set -l dry_run false
     set -l custom_base ""
     set -l custom_title ""
-    
-    argparse 'd/draft' 'dry-run' 'b/base=' 't/title=' 'B/bookmark=' -- $argv
+
+    argparse d/draft dry-run 'B/base=' 't/title=' 'b/bookmark=' -- $argv
     or return 1
 
     if set -q _flag_draft
-        set draft_flag "--draft"
+        set draft_flag --draft
     end
 
     if set -q _flag_dry_run
@@ -30,13 +30,13 @@ function ghpr --description "Create GitHub PR with conventional commit format"
     if set -q _flag_bookmark
         set target_bookmark $_flag_bookmark
     end
-    
+
     # Check dependencies
     if not type -q gh
         echo "Error: gh (GitHub CLI) not installed"
         return 1
     end
-    
+
     # Detect VCS type using proper checks
     set -l is_jj false
     if type -q jj; and jj workspace root >/dev/null 2>&1
@@ -81,7 +81,7 @@ function ghpr --description "Create GitHub PR with conventional commit format"
             end
         end
     end
-    
+
     # Get current branch/bookmark name
     set -l current_branch ""
     if test -n "$target_bookmark"
@@ -127,7 +127,7 @@ function ghpr --description "Create GitHub PR with conventional commit format"
             return 1
         end
     end
-    
+
     # Determine base branch
     set -l base_branch ""
     if test -n "$custom_base"
@@ -136,45 +136,49 @@ function ghpr --description "Create GitHub PR with conventional commit format"
         # Extract base from trunk() - results in "main@origin" or "master@origin", extract just the branch name
         set base_branch (jj log -r 'trunk()' -T 'bookmarks.join(" ")' --no-graph 2>/dev/null | string trim | string replace -r '@.*$' '' | head -n1)
         if test -z "$base_branch"
-            set base_branch "main"
+            set base_branch main
         end
     else
         # Git: try main, then master
         if git show-ref --verify --quiet refs/heads/main
-            set base_branch "main"
+            set base_branch main
         else if git show-ref --verify --quiet refs/heads/master
-            set base_branch "master"
+            set base_branch master
         else
             # Use repo default
             set base_branch (git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
             if test -z "$base_branch"
-                set base_branch "main" # final fallback
+                set base_branch main # final fallback
             end
         end
     end
 
-    # Detect parent bookmark for stacked PRs (JJ only)
+    echo "✓ Base branch: $base_branch"
+
+    # Detect parent bookmark for stacked PRs (JJ only) — only when no custom base was given
     set -l comparison_base ""
     if test "$is_jj" = true
-        # ancestors() excluding the bookmark commit itself gives us the parent layer
-        set -l parent_bookmark (jj log -r "ancestors($current_branch) & bookmarks() & ~$current_branch" \
-            -T 'bookmarks.join(",")' --no-graph --limit 1 2>/dev/null | \
-            string replace -r '\*' '' | string trim | string split ',' | head -n1)
-
-        set -l trunk_bookmark (jj log -r "trunk()" -T 'bookmarks.join(",")' \
-            --no-graph 2>/dev/null | string trim)
-
-        if test -n "$parent_bookmark" -a "$parent_bookmark" != "$trunk_bookmark"
-            set comparison_base "$parent_bookmark"
-            set base_branch "$parent_bookmark"
+        if test -n "$custom_base"
+            set comparison_base "$custom_base"
         else
-            set comparison_base "trunk()"
+            # ancestors() excluding the bookmark commit itself gives us the parent layer
+            set -l parent_bookmark (jj log -r "ancestors($current_branch) & bookmarks() & ~$current_branch" \
+                -T 'bookmarks.join(",")' --no-graph --limit 1 2>/dev/null | \
+                string replace -r '\*' '' | string trim | string split ',' | head -n1)
+
+            set -l trunk_bookmark (jj log -r "trunk()" -T 'bookmarks.join(",")' \
+                --no-graph 2>/dev/null | string trim)
+
+            if test -n "$parent_bookmark" -a "$parent_bookmark" != "$trunk_bookmark"
+                set comparison_base "$parent_bookmark"
+                set base_branch "$parent_bookmark"
+            else
+                set comparison_base "trunk()"
+            end
         end
     else
         set comparison_base "$base_branch"
     end
-
-    echo "✓ Base branch: $base_branch"
 
     # Bail if a PR already exists for this bookmark — skip AI + gh create
     set -l existing_pr (gh pr list --head $current_branch --state open --json number,url --jq '.[0] // empty | "\(.number)\t\(.url)"' 2>/dev/null)
@@ -217,7 +221,7 @@ function ghpr --description "Create GitHub PR with conventional commit format"
         set commit_messages (git log "$base_branch"..HEAD --pretty=format:"%s%n%b" 2>/dev/null | string collect)
         set changed_files (git diff "$base_branch"...HEAD --name-only 2>/dev/null)
     end
-    
+
     if test -z "$diff_content"
         if test "$is_jj" = true
             echo "⚠ Warning: No changes detected between '$current_branch' and '$comparison_base'"
@@ -225,7 +229,7 @@ function ghpr --description "Create GitHub PR with conventional commit format"
             echo "⚠ Warning: No changes detected between current branch and $base_branch"
         end
     end
-    
+
     # Check for PR template
     set -l template_path ""
     set -l template_content ""
@@ -236,7 +240,7 @@ function ghpr --description "Create GitHub PR with conventional commit format"
             break
         end
     end
-    
+
     # Generate PR title and body via AI
     set -l pr_title ""
     set -l pr_body ""
@@ -244,6 +248,11 @@ function ghpr --description "Create GitHub PR with conventional commit format"
 
     if test -n "$custom_title"
         set pr_title $custom_title
+    end
+
+    set -l oc_model opencode/big-pickle
+    if test (uname -s) = Darwin
+        set oc_model openai/gpt-4o-mini
     end
 
     if type -q opencode
@@ -334,7 +343,7 @@ $truncated_diff
 ## Commit Messages
 $truncated_commit_messages"
 
-        set -l ai_output (printf "%s" $prompt | opencode run --model anthropic/claude-haiku-4-5 --format default 2>/dev/null | string collect)
+        set -l ai_output (printf "%s" $prompt | opencode run --model $oc_model --format default 2>/dev/null | string collect)
 
         if test -n "$ai_output"
             # string match -r with a capture group returns two items: full match, then capture
@@ -344,7 +353,7 @@ $truncated_commit_messages"
             # Write to temp file so awk can extract the body with newlines intact.
             # Fish splits strings on newlines into lists, which destroys formatting.
             set -l tmp (mktemp)
-            printf "%s" $ai_output > $tmp
+            printf "%s" $ai_output >$tmp
             set -l ai_body (awk '/^BODY:/{found=1; next} found{print}' $tmp | string collect)
             rm -f $tmp
 
@@ -378,7 +387,7 @@ $truncated_commit_messages"
         end
         echo "⚠ Using fallback title: $pr_title"
     end
-    
+
     # Validation hold - show preview
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -387,15 +396,14 @@ $truncated_commit_messages"
     echo ""
     echo "Title: $pr_title"
     echo "Base:  $base_branch"
-    
     echo "Head:  $current_branch"
-    
+
     if test -n "$draft_flag"
         echo "Draft: Yes"
     end
-    
+
     echo ""
-    
+
     if test "$use_fill" = true
         echo "Body: (will use --fill, gh will open editor)"
     else
@@ -404,15 +412,15 @@ $truncated_commit_messages"
         printf "%s\n" $pr_body
         echo "────────────────────────────────────────────────────"
     end
-    
+
     echo ""
-    
+
     # Dry run exits here
     if test "$dry_run" = true
         echo "Dry run - no PR created"
         return 0
     end
-    
+
     # Prompt for confirmation with edit options
     while true
         read -P "Create this PR? [Y/n/e(dit body)/t(itle)]: " -l confirm
@@ -436,7 +444,7 @@ $truncated_commit_messages"
 
                 # Git-commit-style: first line = title, blank line, rest = body
                 set -l temp_file (mktemp)
-                printf "%s\n\n%s\n" $pr_title $pr_body > $temp_file
+                printf "%s\n\n%s\n" $pr_title $pr_body >$temp_file
 
                 # Split to handle editors with args (e.g. "code --wait")
                 set -l editor_cmd
@@ -459,6 +467,7 @@ $truncated_commit_messages"
                 set pr_body $new_body
                 rm $temp_file
 
+                # Show updated preview
                 echo ""
                 echo "Title: $pr_title"
                 echo "Updated Body:"
@@ -471,7 +480,7 @@ $truncated_commit_messages"
                 return 0
         end
     end
-    
+
     # Create PR
     echo ""
     echo "✓ Creating PR..."
@@ -479,7 +488,7 @@ $truncated_commit_messages"
     set -l body_file ""
     if test "$use_fill" = false
         set body_file (mktemp)
-        printf "%s\n" $pr_body > $body_file
+        printf "%s\n" $pr_body >$body_file
     end
 
     set -l gh_status 0

--- a/fish/functions/ghpr.fish
+++ b/fish/functions/ghpr.fish
@@ -160,8 +160,6 @@ function ghpr --description "Create GitHub PR with conventional commit format"
         end
     end
 
-    echo "✓ Base branch: $base_branch"
-
     # Detect parent bookmark for stacked PRs (JJ only) — only when no custom base was given
     set -l comparison_base ""
     if test "$is_jj" = true
@@ -186,6 +184,8 @@ function ghpr --description "Create GitHub PR with conventional commit format"
     else
         set comparison_base "$base_branch"
     end
+
+    echo "✓ Base branch: $base_branch"
 
     # Bail if a PR already exists for this bookmark — skip AI + gh create
     set -l existing_pr (gh pr list --head $current_branch --state open --json number,url --jq '.[0] // empty | "\(.number)\t\(.url)"' 2>/dev/null)

--- a/fish/functions/ghpr.fish
+++ b/fish/functions/ghpr.fish
@@ -7,8 +7,13 @@ function ghpr --description "Create GitHub PR with conventional commit format"
     set -l custom_base ""
     set -l custom_title ""
 
-    argparse d/draft dry-run 'B/base=' 't/title=' 'b/bookmark=' -- $argv
+    argparse d/draft dry-run v/verbose 'B/base=' 't/title=' 'b/bookmark=' -- $argv
     or return 1
+
+    set -l verbose false
+    if set -q _flag_verbose
+        set verbose true
+    end
 
     if set -q _flag_draft
         set draft_flag --draft
@@ -102,7 +107,9 @@ function ghpr --description "Create GitHub PR with conventional commit format"
         return 1
     end
 
-    echo "✓ Current "(test "$is_jj" = true; and echo "bookmark"; or echo "branch")": $current_branch"
+    set -l _ref_kind branch
+    test "$is_jj" = true; and set _ref_kind bookmark
+    echo "✓ Current $_ref_kind: $current_branch"
 
     # Ensure changes are pushed before creating a PR
     if test "$is_jj" = true
@@ -111,7 +118,7 @@ function ghpr --description "Create GitHub PR with conventional commit format"
         set -l bookmark_block (jj bookmark list --all-remotes 2>/dev/null | grep -A3 -- "^$escaped_branch:")
         set -l has_origin (echo $bookmark_block | string match -r '@origin:')
         set -l not_created (echo $bookmark_block | string match -r 'not created yet')
-        if test -z "$has_origin" -o -n "$not_created"
+        if test -z "$has_origin"; or test -n "$not_created"
             echo "Error: Bookmark '$current_branch' has not been pushed to origin."
             echo "  Push with: jj git push -b $current_branch"
             return 1
@@ -169,7 +176,7 @@ function ghpr --description "Create GitHub PR with conventional commit format"
             set -l trunk_bookmark (jj log -r "trunk()" -T 'bookmarks.join(",")' \
                 --no-graph 2>/dev/null | string trim)
 
-            if test -n "$parent_bookmark" -a "$parent_bookmark" != "$trunk_bookmark"
+            if test -n "$parent_bookmark"; and test "$parent_bookmark" != "$trunk_bookmark"
                 set comparison_base "$parent_bookmark"
                 set base_branch "$parent_bookmark"
             else
@@ -236,7 +243,7 @@ function ghpr --description "Create GitHub PR with conventional commit format"
     for path in .github/pull_request_template.md .github/PULL_REQUEST_TEMPLATE.md docs/pull_request_template.md
         if test -f $path
             set template_path $path
-            set template_content (cat $path | string collect)
+            set template_content (string collect <$path)
             break
         end
     end
@@ -248,11 +255,6 @@ function ghpr --description "Create GitHub PR with conventional commit format"
 
     if test -n "$custom_title"
         set pr_title $custom_title
-    end
-
-    set -l oc_model opencode/big-pickle
-    if test (uname -s) = Darwin
-        set oc_model openai/gpt-4o-mini
     end
 
     if type -q opencode
@@ -296,10 +298,16 @@ $recent_titles"
 
         set prompt "$prompt
 
-Output format (required - do not deviate):
+Output format — STRICT:
 TITLE: <conventional commit title>
 BODY:
 <PR description>
+
+Output rules:
+- Emit ONLY the two sections above. No preamble (\"Here's the PR...\"), no closing remarks (\"Feel free to modify...\", \"Let me know if...\"), no markdown headers around TITLE/BODY.
+- Do NOT wrap the output in code fences.
+- BODY content may contain markdown; it is the literal PR description.
+- Stop immediately after the final line of the PR description.
 
 Scope rules: scope is optional. Only include a scope if the changes are clearly focused in one area AND recent PR titles in this repo use scopes. Infer the scope from changed file paths. Omit scope entirely if this repo doesn't use them or changes span multiple areas."
 
@@ -343,30 +351,44 @@ $truncated_diff
 ## Commit Messages
 $truncated_commit_messages"
 
-        set -l ai_output (printf "%s" $prompt | opencode run --model $oc_model --format default 2>/dev/null | string collect)
+        set -l oc_in (mktemp)
+        set -l oc_out (mktemp)
+        set -l oc_err (mktemp)
+        printf "%s" $prompt >$oc_in
+        _ai_run (_ai_model) $oc_in $oc_out $oc_err
+        set -l oc_status $status
+        set -l ai_output (string collect <$oc_out)
+        set -l err_text (string collect <$oc_err)
+        rm -f $oc_in $oc_err
 
-        if test -n "$ai_output"
-            # string match -r with a capture group returns two items: full match, then capture
-            set -l title_match (string match -r 'TITLE: (.+)' $ai_output)
-            set -l ai_title $title_match[2]
-
-            # Write to temp file so awk can extract the body with newlines intact.
-            # Fish splits strings on newlines into lists, which destroys formatting.
-            set -l tmp (mktemp)
-            printf "%s" $ai_output >$tmp
-            set -l ai_body (awk '/^BODY:/{found=1; next} found{print}' $tmp | string collect)
-            rm -f $tmp
-
-            if test -n "$ai_title" -a -z "$custom_title"
-                set pr_title (string trim -- $ai_title)
-            end
-            if test -n "$ai_body"
-                set pr_body $ai_body
+        if test "$verbose" = true; and begin; test $oc_status -ne 0; or test -z "$ai_output"; end
+            echo "⚠ opencode exit=$oc_status, stdout_len="(string length -- $ai_output)", stderr_len="(string length -- $err_text)
+            if test -n "$err_text"
+                echo "⚠ opencode stderr:"
+                printf "%s\n" $err_text | string replace -r '^' '   '
             end
         end
 
+        if test -n "$ai_output"
+            set -l ai_title (_ai_extract_marker TITLE $oc_out | string collect)
+            set -l ai_body (_ai_extract_marker BODY $oc_out | string collect)
+
+            if test -n "$ai_title"; and test -z "$custom_title"
+                set pr_title (string trim -- $ai_title)
+            end
+            if test -n "$ai_body"
+                set ai_body (printf "%s" $ai_body | _ai_strip_trailer | string collect)
+                set pr_body (string trim -- $ai_body)
+            end
+        end
+        rm -f $oc_out
+
         if test -z "$pr_body"
             echo "⚠ OpenCode failed to generate output, will use --fill"
+            if test "$verbose" = true; and test -n "$ai_output"
+                echo "⚠ Raw ai_output (first 500 chars, no TITLE/BODY markers found):"
+                printf "%s\n" (string sub -l 500 -- $ai_output) | string replace -r '^' '   '
+            end
             set use_fill true
         end
     else
@@ -376,7 +398,7 @@ $truncated_commit_messages"
 
     # Fallback title from branch name if AI didn't produce one
     if test -z "$pr_title"
-        if test -n "$branch_type" -a -n "$branch_ticket"
+        if test -n "$branch_type"; and test -n "$branch_ticket"
             if test -n "$branch_desc"
                 set pr_title "$branch_type: $branch_ticket $branch_desc"
             else

--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,13 @@ rm -rf "$HOME/.config/fish"
 echo Populating config and local scripts...
 stow -v2 .
 stow -v2 -t ~/.local -S dot-local --dotfiles
-stow -v2 -t ~ -S zsh gitmux ai --dotfiles
+stow -v2 -t ~ -S zsh gitmux --dotfiles
+# stow 2.3.1 bug: can't traverse dot-prefixed dirs that exist as real dirs at target
+# Manually symlink ai package contents
+ln -sf "$HOME/.dotfiles/ai/dot-claude/CLAUDE.md" "$HOME/.claude/CLAUDE.md"
+ln -sfn "$HOME/.dotfiles/ai/dot-codex" "$HOME/.codex"
+mkdir -p "$HOME/.config/opencode"
+ln -sf "$HOME/.dotfiles/ai/dot-config/opencode/AGENTS.md" "$HOME/.config/opencode/AGENTS.md"
 stow -v2 -t ~/.ssh -S dot-ssh --dotfiles
 
 echo "Converting any PKCS#8 SSH keys to OpenSSH format..."

--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,7 @@ brew install lazygit asciinema agg jj mise gh dlvhdr/formulae/diffnav
 echo "Installing neovim via brew (you will likely want to change this)"
 brew install neovim
 
-mkdir -p ~/.local ~/.config ~/.ssh
+mkdir -p ~/.local ~/.config ~/.ssh ~/.claude
 pushd "$HOME/.dotfiles" || exit
 
 echo Clearing install files to avoid stow conflicts...


### PR DESCRIPTION
## Summary

- Switch `ghpr` fish function to use `opencode/big-pickle` model on Linux (free) instead of Claude
- Use `openai/gpt-4o-mini` on macOS as fallback
- Fix argparse flag ordering (`-b` for bookmark was conflicting)
- Only detect parent bookmark for stacked PRs when no custom base is provided
- Add manual symlinks for AI configs in `install.sh` (workaround for stow bug with dot-prefixed directories)

## Changes

- `fish/functions/ghpr.fish`: Use OS-detected AI model, fix flag parsing, improve stacked PR detection
- `install.sh`: Replace stow of `ai` package with manual symlinks for claude/codex/opencode configs
