### PR TITLE
Use Helium instead of Chromium in webapp scripts

### DIFF
--- a/dot-local/bin/launch-webapp
+++ b/dot-local/bin/launch-webapp
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Launch the passed in URL as a web app in the default browser (or chromium if the default doesn't support --app).
+# Launch the passed in URL as a web app in the default browser (or Helium if default doesn't support --app).
 
 browser=$(xdg-settings get default-web-browser)
 

--- a/dot-local/bin/webapp-install
+++ b/dot-local/bin/webapp-install
@@ -92,7 +92,6 @@ fi
 # Use custom exec if provided, otherwise default behavior
 EXEC_COMMAND="${CUSTOM_EXEC:-launch-webapp $APP_URL}"
 
-# Create application .desktop file
 DESKTOP_FILE="$HOME/.local/share/applications/$APP_NAME.desktop"
 
 cat >"$DESKTOP_FILE" <<EOF


### PR DESCRIPTION
- Update `launch-webapp` to reference Helium instead of Chromium in comment
- Remove redundant comment from `webapp-install`
