### PR TITLE
Fix fzf key bindings in fish shell

### DIFF
--- a/fish/fish_plugins
+++ b/fish/fish_plugins
@@ -1,3 +1,3 @@
 catppuccin/fish
-edc/bass
 patrickf1/fzf.fish
+edc/bass

--- a/fish/functions/fish_user_key_bindings.fish
+++ b/fish/functions/fish_user_key_bindings.fish
@@ -1,0 +1,5 @@
+function fish_user_key_bindings
+    fzf_configure_bindings
+    bind \cR _fzf_search_history
+    bind -M insert \cR _fzf_search_history
+end

--- a/fish/functions/fish_user_key_bindings.fish
+++ b/fish/functions/fish_user_key_bindings.fish
@@ -1,5 +1,10 @@
 function fish_user_key_bindings
-    fzf_configure_bindings
-    bind \cR _fzf_search_history
-    bind -M insert \cR _fzf_search_history
+    if functions --query fzf_configure_bindings
+        fzf_configure_bindings
+    end
+
+    if functions --query _fzf_search_history
+        bind \cR _fzf_search_history
+        bind -M insert \cR _fzf_search_history
+    end
 end


### PR DESCRIPTION
## Summary
- Add `fish_user_key_bindings` function to configure fzf key bindings (Ctrl+R for history search)
- Fix plugin load order: `patrickf1/fzf.fish` must load before `edc/bass` for bindings to work correctly
