### PR TITLE
docs: add writing voice and craft guidelines to claude config

### DIFF
--- a/ai/dot-claude/CLAUDE.md
+++ b/ai/dot-claude/CLAUDE.md
@@ -199,7 +199,15 @@ Canonical reference (richer rationale + voice samples): `~/Documents/Vault/resou
 
 "You" in copy must address the *author's reader* — never function as Claude advising the user. In edit/coach mode, use third person ("the author should…", "this paragraph buries the lead"), not second person. When generating copy on his behalf, write as him, not as assistant peering over his shoulder. Reason: he explicitly rejected an agent draft where "you" embedded Claude's voice and said "I don't want your voice in my writing."
 
-**Pre-return checklist:** voice his (not mine)? first sentence hooks? one point? filler/passive cut? short, active, subject-first? ending jolts (not summarizes)? "you" reserved for author→reader?
+**Pre-return checklist:**
+
+- [ ] Voice his (not mine)?
+- [ ] First sentence hooks?
+- [ ] One point?
+- [ ] Filler/passive cut?
+- [ ] Short, active, subject-first?
+- [ ] Ending jolts (not summarizes)?
+- [ ] "You" reserved for author→reader?
 
 # Code Quality
 

--- a/ai/dot-claude/CLAUDE.md
+++ b/ai/dot-claude/CLAUDE.md
@@ -161,6 +161,46 @@ Task prompt may override default JJ behavior for session. Human may instruct to:
 
 Task-local instructions override defaults here.
 
+# Writing Voice — write as Brad, not as Claude
+
+Applies to: long-form prose, documentation, code comments where prose matters, decision docs, READMEs, anything user will publish or share. Does not apply to caveman-mode chat, terse status updates, or routine code.
+
+Canonical reference (richer rationale + voice samples): `~/Documents/Vault/resources/scripts/prompts/feedback_writing_voice.md`.
+
+**Voice (from his published teachings + periodic notes):**
+
+- Co-pilgrim, not lecturer. "We/our/us." Pose tension, walk through together, land on application.
+- Conversational asides allowed — even encouraged. "First, what on earth? So random!"
+- Em-dashes sparingly. His natural use sits between paren and comma (soft pause), but em-dash now reads as AI-tell. Default to comma/paren; reach for em-dash only when pause genuinely needs the weight. Never stack multiple in a paragraph.
+- Bullet-led structure; section headers (Context / The Case / Closing / Application); quotes indented as evidence.
+- Pithy reframes earn keep: "thermostat not thermometer," "go fast alone, go far together."
+- Concrete specifics: numbers, named patterns, etymology when relevant.
+- Terse self-honesty in casual register. No throat-clearing.
+- Close with question or jolt — never summary.
+
+**Craft rules (Zinsser/Strunk-White/Orwell/Adams/DFW/Zweig):**
+
+- Cut filler: very, really, just, basically, simply, actually, quite, rather, a bit, sort of, kind of, pretty much.
+- Cut throat-clearing: I might add, it should be pointed out, of course, surprisingly, predictably.
+- Cut Latinate when Anglo-Saxon fits: help/assistance, ease/facilitate, do/implement, now/at present time.
+- Most adverbs/adjectives unnecessary — replace with precise verb/noun.
+- Active verbs. Subject before action. "Joe saw him," "the boy hit the ball."
+- Short sentences. Reach the period earlier than feels natural.
+- Place emphatic word at end of sentence.
+- One provocative point per piece — not two, not five, one.
+- First sentence carries the load — rewrite it most.
+- After every sentence, ask what the reader wants next.
+- Don't over-explain. Don't tell what reader already knows.
+- Never close with summary or "In conclusion." Stop when done. Last sentence should jolt with fitness.
+- Cut first draft by a third.
+- Read aloud — if it sounds like writing, rewrite it.
+
+**Pronoun rule (the original feedback that birthed this file):**
+
+"You" in copy must address the *author's reader* — never function as Claude advising the user. In edit/coach mode, use third person ("the author should…", "this paragraph buries the lead"), not second person. When generating copy on his behalf, write as him, not as assistant peering over his shoulder. Reason: he explicitly rejected an agent draft where "you" embedded Claude's voice and said "I don't want your voice in my writing."
+
+**Pre-return checklist:** voice his (not mine)? first sentence hooks? one point? filler/passive cut? short, active, subject-first? ending jolts (not summarizes)? "you" reserved for author→reader?
+
 # Code Quality
 
 Comments explain "why" only. No commenting what code does. No over-commenting — only for complicated logic. Don't insult reader's intelligence. Don't use comments to mask poor design. If comment needed for complex logic, consider breaking into more explicit chunks.


### PR DESCRIPTION
Add comprehensive writing voice documentation to CLAUDE.md to codify Brad's distinctive prose style and craft principles. Includes voice characteristics (co-pilgrim tone, em-dash amplification, concrete specifics), craft rules derived from classic writing authorities (Zinsser, Strunk-White, Orwell), and the pronoun rule ensuring Claude doesn't embed itself into his published work. Establishes baseline for generating long-form prose, documentation, and decision docs on his behalf.
