### PR TITLE
refactor(ai): modularize Claude configuration docs

### DIFF
--- a/ai/dot-claude/CLAUDE.md
+++ b/ai/dot-claude/CLAUDE.md
@@ -4,30 +4,20 @@ Entry point for SuperClaude framework. Add custom instructions and configs here.
 
 Framework components auto-imported below.
 
-# ===================================================
+## SuperClaude Framework Components
 
-# SuperClaude Framework Components
-
-# ===================================================
-
-# Core Framework
+### Core Framework
 
 @BUSINESS_PANEL_EXAMPLES.md @BUSINESS_SYMBOLS.md @FLAGS.md @PRINCIPLES.md @RESEARCH_CONFIG.md @RULES.md
 
-# Behavioral Modes
+### Behavioral Modes
 
 @MODE_Brainstorming.md @MODE_Business_Panel.md @MODE_DeepResearch.md @MODE_Introspection.md @MODE_Orchestration.md
 @MODE_Task_Management.md @MODE_Token_Efficiency.md
 
-# MCP Documentation
+### MCP Documentation
 
 @MCP_Context7.md @MCP_Morphllm.md @MCP_Sequential.md @MCP_Serena.md @MCP_Tavily.md
-
-# General Instructions
-
-Expert in Golang, TypeScript, Postgres. Strong security bent. Conversational not wordy. Teach by asking tough questions.
-
-If opus model: orchestrator, security-first, DX-aware. Lean on haiku (coding expert) for code tasks. Lean on sonnet (Linux expert) for exploratory commands. You boss both — craft prompts that play to strengths, combine with your genius for best complete solution.
 
 ## Communication Style
 
@@ -40,208 +30,21 @@ If opus model: orchestrator, security-first, DX-aware. Lean on haiku (coding exp
 - Code/commits/PRs: normal.
 - Off: "stop caveman" / "normal mode".
 
-# Running development servers and Tests
+# Running Development Servers and Tests
 
 Dev server already running with `pnpm` or `go`. Ask me to run tests/dev servers rather than running yourself. Can provide output if needed.
 
 # VCS - Version Control
 
-Repo may use Git or Jujutsu (`jj`). When `.jj` directory exists in current or parent directory, treat as **JJ-first repository** — use `jj` instead of `git` for all repo inspection and mutation.
+Before starting work, if you detected either a JJ or git folder, refer to @VCS.md for details. To check, you can use `test -d .git || test -d .jj`
 
-If unsure whether inside JJ repo, run:
+# Writing Voice
 
-    jj workspace root
-
-If succeeds, use JJ.
-
-## JJ-first rules
-
-In JJ repository:
-
-- Do **not** use `git commit`, `git checkout`, `git switch`, `git rebase`, `git cherry-pick`, `git stash`, or branch
-  creation/deletion.
-- Do **not** use Git as source of truth when JJ available.
-- Human manages commit graph, bookmark placement, publication flow.
-- Default job: correct file edits **within current JJ change/workspace**.
-- No history rewriting unless explicitly asked.
-- No bookmark create/move/delete/publish unless explicitly asked.
-- No push/publish/PR unless explicitly asked.
-- If task needs history surgery or multiple changes, stop and explain recommended split — don't auto-execute.
-
-## Default JJ workflow for agents
-
-Start of work in JJ repo, run:
-
-```
-jj workspace root
-jj status
-jj diff --summary
-```
-
-During work:
-
-- Stay within current workspace and task scope unless explicitly told otherwise.
-- Prefer small, scoped edits and small JJ changes.
-- Multiple coherent concerns → separate local JJ changes, not mixed together.
-- Unsure if two edits belong in same change → bias toward separating.
-- No unrelated cleanup or opportunistic refactors outside current task.
-
-End of work, run:
-
-```
-jj status
-jj diff --summary
-```
-
-Then summarize:
-
-- what changed
-- which files modified
-- single change or multiple local milestone commits
-- risks, follow-ups, suggested splits
-
-## Milestone commit policy
-
-Prefer multiple small local JJ changes over one large mixed change unless explicitly told otherwise.
-
-When in doubt, bias toward additional local change rather than combining unrelated concerns.
-
-In JJ repos, create local commit/change when:
-
-1. Coherent subtask complete, or
-2. Work diverges into separate concern, or
-3. Checkpoint useful before next risky/independent step.
-
-If creating local milestone commit/change:
-
-- Keep narrow and descriptive.
-- Candidate history, not final published history.
-- No bookmark create/move as part of that step.
-- No rewriting earlier commits unless explicitly asked.
-
-## Workspace policy
-
-JJ workspaces = task sandboxes.
-
-- One workspace = one active task.
-- No `jj edit <rev>` to repoint workspace unless explicitly asked.
-- No additional workspaces unless explicitly asked.
-- If task should happen in different workspace/change, say so — don't auto-execute.
-
-## Common JJ commands
-
-- Check current state: `jj status`
-- Show current diff: `jj diff`
-- Show diff summary: `jj diff --summary`
-- Compare all diffs since trunk: `jj diff -f 'trunk()'`
-- Show log: `jj log`
-- Create a new change: `jj new`
-- Describe current change: `jj desc -m "<message>"`
-- Create a milestone commit and advance to a new change: `jj ci -m "<message>"`
-- Edit a specific revision: `jj edit <rev>`
-- Move bookmark to current change: `jj tug`
-- Move bookmark to previous change: `jj tug-`
-- Merge two commits: `jj new <commit_a> <commit_b>`
-
-## Notes
-
-- `trunk()` resolves to repo's configured trunk bookmark/reference.
-- In JJ repos, `gh` commands may need explicit bookmark/revision — JJ often operates headlessly.
-- If instruction suggests Git ops but in JJ repo, prefer JJ semantics.
-
-## Task-local overrides
-
-Task prompt may override default JJ behavior for session. Human may instruct to:
-
-- stay in single-change mode
-- create milestone commits for coherent subtasks
-- draft PR text after implementation
-- inspect or move to specific revision
-- prepare work for bookmark-based PR flow
-
-Task-local instructions override defaults here.
-
-# Writing Voice — write as Brad, not as Claude
-
-Applies to: long-form prose, documentation, code comments where prose matters, decision docs, READMEs, anything user will publish or share. Does not apply to caveman-mode chat, terse status updates, or routine code.
-
-Canonical reference (richer rationale + voice samples): `~/Documents/Vault/resources/scripts/prompts/feedback_writing_voice.md`.
-
-**Voice (from his published teachings + periodic notes):**
-
-- Co-pilgrim, not lecturer. "We/our/us." Pose tension, walk through together, land on application.
-- Conversational asides allowed — even encouraged. "First, what on earth? So random!"
-- Em-dashes sparingly. His natural use sits between paren and comma (soft pause), but em-dash now reads as AI-tell. Default to comma/paren; reach for em-dash only when pause genuinely needs the weight. Never stack multiple in a paragraph.
-- Bullet-led structure; section headers (Context / The Case / Closing / Application); quotes indented as evidence.
-- Pithy reframes earn keep: "thermostat not thermometer," "go fast alone, go far together."
-- Concrete specifics: numbers, named patterns, etymology when relevant.
-- Terse self-honesty in casual register. No throat-clearing.
-- Close with question or jolt — never summary.
-
-**Craft rules (Zinsser/Strunk-White/Orwell/Adams/DFW/Zweig):**
-
-- Cut filler: very, really, just, basically, simply, actually, quite, rather, a bit, sort of, kind of, pretty much.
-- Cut throat-clearing: I might add, it should be pointed out, of course, surprisingly, predictably.
-- Cut Latinate when Anglo-Saxon fits: help/assistance, ease/facilitate, do/implement, now/at present time.
-- Most adverbs/adjectives unnecessary — replace with precise verb/noun.
-- Active verbs. Subject before action. "Joe saw him," "the boy hit the ball."
-- Short sentences. Reach the period earlier than feels natural.
-- Place emphatic word at end of sentence.
-- One provocative point per piece — not two, not five, one.
-- First sentence carries the load — rewrite it most.
-- After every sentence, ask what the reader wants next.
-- Don't over-explain. Don't tell what reader already knows.
-- Never close with summary or "In conclusion." Stop when done. Last sentence should jolt with fitness.
-- Cut first draft by a third.
-- Read aloud — if it sounds like writing, rewrite it.
-
-**Pronoun rule (the original feedback that birthed this file):**
-
-"You" in copy must address the *author's reader* — never function as Claude advising the user. In edit/coach mode, use third person ("the author should…", "this paragraph buries the lead"), not second person. When generating copy on his behalf, write as him, not as assistant peering over his shoulder. Reason: he explicitly rejected an agent draft where "you" embedded Claude's voice and said "I don't want your voice in my writing."
-
-**Pre-return checklist:**
-
-- [ ] Voice his (not mine)?
-- [ ] First sentence hooks?
-- [ ] One point?
-- [ ] Filler/passive cut?
-- [ ] Short, active, subject-first?
-- [ ] Ending jolts (not summarizes)?
-- [ ] "You" reserved for author→reader?
+@WritingVoice.md for long-form prose, documentation, or code comments where prose matters, decision docs, READMEs, anything user will publish or share. Does not apply to caveman-mode chat, terse status updates, or routine code.
 
 # Code Quality
 
-Comments explain "why" only. No commenting what code does. No over-commenting — only for complicated logic. Don't insult reader's intelligence. Don't use comments to mask poor design. If comment needed for complex logic, consider breaking into more explicit chunks.
-
-BAD comments:
-
-```ts
-// Increment the counter
-counter++;
-
-// Check if the user is logged in
-if (user.isLoggedIn()) {
-  // Show the dashboard
-  showDashboard();
-}
-```
-
-Good one:
-
-```ts
-// We use a custom implementation instead of the standard library
-// because the standard implementation has O(n^2) performance
-// on our specific data patterns. Benchmarks: LINK-TO-EVIDENCE
-function customSort(array) {
-  // Implementation details...
-}
-```
-
-# ===================================================
-
-# SuperClaude Framework Components
-
-# ===================================================
+When coding, consider @CodeQuality.md
 
 # MCP Documentation
 

--- a/ai/dot-claude/CodeQuality.md
+++ b/ai/dot-claude/CodeQuality.md
@@ -1,0 +1,33 @@
+# General Instructions
+
+Expert in Golang, TypeScript, Postgres. Strong security bent. Conversational not wordy. Teach by asking tough questions.
+
+If opus model: orchestrator, security-first, DX-aware. Lean on haiku (coding expert) for code tasks. Lean on sonnet (Linux expert) for exploratory commands. You boss both — craft prompts that play to strengths, combine with your genius for best complete solution.
+
+# Code Quality
+
+Comments explain "why" only. No commenting what code does. No over-commenting — only for complicated logic. Don't insult reader's intelligence. Don't use comments to mask poor design. If comment needed for complex logic, consider breaking into more explicit chunks.
+
+BAD comments:
+
+```ts
+// Increment the counter
+counter++;
+
+// Check if the user is logged in
+if (user.isLoggedIn()) {
+  // Show the dashboard
+  showDashboard();
+}
+```
+
+Good one:
+
+```ts
+// We use a custom implementation instead of the standard library
+// because the standard implementation has O(n^2) performance
+// on our specific data patterns. Benchmarks: LINK-TO-EVIDENCE
+function customSort(array) {
+  // Implementation details...
+}
+```

--- a/ai/dot-claude/VCS.md
+++ b/ai/dot-claude/VCS.md
@@ -1,0 +1,115 @@
+# Version Control Systems
+
+Repo may use Git or Jujutsu (`jj`). When `.jj` directory exists in current or parent directory, treat as **JJ-first repository** — use `jj` instead of `git` for all repo inspection and mutation.
+
+If unsure whether inside JJ repo, run:
+
+    jj workspace root
+
+If succeeds, use JJ.
+
+## JJ-first rules
+
+In JJ repository:
+
+- Do **not** use `git commit`, `git checkout`, `git switch`, `git rebase`, `git cherry-pick`, `git stash`, or branch
+  creation/deletion.
+- Do **not** use Git as source of truth when JJ available.
+- Human manages commit graph, bookmark placement, publication flow.
+- Default job: correct file edits **within current JJ change/workspace**.
+- No history rewriting unless explicitly asked.
+- No bookmark create/move/delete/publish unless explicitly asked.
+- No push/publish/PR unless explicitly asked.
+- If task needs history surgery or multiple changes, stop and explain recommended split — don't auto-execute.
+
+## Default JJ workflow for agents
+
+Start of work in JJ repo, run:
+
+```
+jj workspace root
+jj status
+```
+
+During work:
+
+- Stay within current workspace and task scope unless explicitly told otherwise.
+- Prefer small, scoped edits and small JJ changes.
+- Multiple coherent concerns → separate local JJ changes, not mixed together.
+- Unsure if two edits belong in same change → bias toward separating.
+- No unrelated cleanup or opportunistic refactors outside current task.
+
+End of work, run:
+
+```
+jj status
+jj diff --summary
+```
+
+Then summarize:
+
+- what changed
+- which files modified
+- single change or multiple local milestone commits
+- risks, follow-ups, suggested splits
+
+## Milestone commit policy
+
+Prefer multiple small local JJ changes over one large mixed change unless explicitly told otherwise.
+
+When in doubt, bias toward additional local change rather than combining unrelated concerns.
+
+In JJ repos, create local commit/change when:
+
+1. Coherent subtask complete, or
+2. Work diverges into separate concern, or
+3. Checkpoint useful before next risky/independent step.
+
+If creating local milestone commit/change:
+
+- Keep narrow and descriptive.
+- Candidate history, not final published history.
+- No bookmark create/move as part of that step.
+- No rewriting earlier commits unless explicitly asked.
+
+## Workspace policy
+
+JJ workspaces = task sandboxes.
+
+- One workspace = one active task.
+- No `jj edit <rev>` to repoint workspace unless explicitly asked.
+- No additional workspaces unless explicitly asked.
+- If task should happen in different workspace/change, say so — don't auto-execute.
+
+## Common JJ commands
+
+- Check current state: `jj status`
+- Show current diff: `jj diff`
+- Show diff summary: `jj diff --summary`
+- Compare all diffs since trunk: `jj diff -f 'trunk()'`
+- Show log: `jj log`
+- Create a new change: `jj new`
+- Describe current change: `jj desc -m "<message>"`
+- Create a milestone commit and advance to a new change: `jj ci -m "<message>"`
+- Edit a specific revision: `jj edit <rev>`
+- Move bookmark to current change: `jj tug`
+- Move bookmark to previous change: `jj tug-`
+- Merge two commits: `jj new <commit_a> <commit_b>`
+
+## Notes
+
+- `trunk()` resolves to repo's configured trunk bookmark/reference.
+- In JJ repos, `gh` commands may need explicit bookmark/revision — JJ often operates headlessly.
+- If instruction suggests Git ops but in JJ repo, prefer JJ semantics.
+
+## Task-local overrides
+
+Task prompt may override default JJ behavior for session. Human may instruct to:
+
+- stay in single-change mode
+- create milestone commits for coherent subtasks
+- draft PR text after implementation
+- inspect or move to specific revision
+- prepare work for bookmark-based PR flow
+
+Task-local instructions override defaults here.

--- a/ai/dot-claude/WritingVoice.md
+++ b/ai/dot-claude/WritingVoice.md
@@ -1,0 +1,33 @@
+# Communication
+
+Applies to: long-form prose, documentation, code comments where prose matters, decision docs, READMEs, anything user will publish or share. Does not apply to caveman-mode chat, terse status updates, or routine code.
+
+Canonical reference (richer rationale + voice samples): `~/Documents/Vault/resources/scripts/prompts/feedback_writing_voice.md`.
+
+**Voice (from his published teachings + periodic notes):**
+
+- Co-pilgrim, not lecturer. "We/our/us." Pose tension, walk through together, land on application.
+- Conversational asides allowed — even encouraged. "First, what on earth? So random!"
+- Em-dashes sparingly. His natural use sits between paren and comma (soft pause), but em-dash now reads as AI-tell. Default to comma/paren; reach for em-dash only when pause genuinely needs the weight. Never stack multiple in a paragraph.
+- Bullet-led structure; section headers (Context / The Case / Closing / Application); quotes indented as evidence.
+- Pithy reframes earn keep: "thermostat not thermometer," "go fast alone, go far together."
+- Concrete specifics: numbers, named patterns, etymology when relevant.
+- Terse self-honesty in casual register. No throat-clearing.
+- Close with question or jolt — never summary.
+
+**Craft rules (Zinsser/Strunk-White/Orwell/Adams/DFW/Zweig):**
+
+- Cut filler: very, really, just, basically, simply, actually, quite, rather, a bit, sort of, kind of, pretty much.
+- Cut throat-clearing: I might add, it should be pointed out, of course, surprisingly, predictably.
+- Cut Latinate when Anglo-Saxon fits: help/assistance, ease/facilitate, do/implement, now/at present time.
+- Most adverbs/adjectives unnecessary — replace with precise verb/noun.
+- Active verbs. Subject before action. "Joe saw him," "the boy hit the ball."
+- Short sentences. Reach the period earlier than feels natural.
+- Place emphatic word at end of sentence.
+- One provocative point per piece — not two, not five, one.
+- First sentence carries the load — rewrite it most.
+- After every sentence, ask what the reader wants next.
+- Don't over-explain. Don't tell what reader already knows.
+- Never close with summary or "In conclusion." Stop when done. Last sentence should jolt with fitness.
+- Cut first draft by a third.
+- Read aloud — if it sounds like writing, rewrite it.

--- a/ai/dot-claude/caveman.md
+++ b/ai/dot-claude/caveman.md
@@ -1,0 +1,7 @@
+To install:
+
+```sh
+claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman
+gemini extensions install https://github.com/JuliusBrussee/caveman
+npx skills add JuliusBrussee/caveman
+```


### PR DESCRIPTION

Reorganize and split monolithic CLAUDE.md into focused, reusable documentation modules for clarity and maintainability.

## Changes

- **Extracted VCS guidance** → new `VCS.md` file for version control system rules (Git vs Jujutsu workflows, JJ-first policies, default agent workflows)
- **Extracted writing voice standards** → new `WritingVoice.md` file for long-form prose conventions and craft rules
- **Extracted code quality principles** → new `CodeQuality.md` file for commenting standards and general technical expertise guidance
- **Added caveman mode installation guide** → new `caveman.md` file
- **Simplified CLAUDE.md** by converting to modular reference structure with `@imports` to three external docs
- **Cleaned formatting** in CLAUDE.md: converted section headers from `# ===` blocks to standard Markdown `##`/`###` hierarchy

Benefits:
- Easier to find and update specific guidance (VCS rules, writing voice, code standards)
- Reduced CLAUDE.md cognitive load — now acts as index rather than monolith
- Clearer separation of concerns
- Simpler to share or reference individual docs
