### PR TITLE
fix(ghostty): prioritize omarchy theme in color configuration

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -38,3 +38,7 @@ end
 set -gx GOPRIVATE "github.com/virtru-corp/*"
 set -gx GONOPROXY "github.com/virtru-corp/*"
 set -gx GONOSUMDB "github.com/virtru-corp/*"
+
+### MANAGED BY RANCHER DESKTOP START (DO NOT EDIT)
+set --export --prepend PATH "/Users/brad.robinson/.rd/bin"
+### MANAGED BY RANCHER DESKTOP END (DO NOT EDIT)

--- a/ghostty/config
+++ b/ghostty/config
@@ -1,5 +1,5 @@
-config-file = ?"~/.config/ghostty/auto/theme.ghostty"
 config-file = ?"~/.config/omarchy/current/theme/ghostty.conf"
+config-file = ?"~/.config/ghostty/auto/theme.ghostty"
 background-blur-radius = 20
 
 # Font

--- a/jj/config.toml
+++ b/jj/config.toml
@@ -169,7 +169,7 @@ git_push_bookmark = '"temp/" ++ change_id.short()'
 # Alternative: 'format_short_signature(signature)' = 'signature.email().local()'
 'format_short_signature(signature)' = 'signature.name()'
 workspace_markers = "label('working_copy', if(working_copies, working_copies ++ ' ', ''))"
-my_default_log = "change_id.shortest(8) ++ if(divergent, format_change_offset(self), '') ++ ' - ' ++ workspace_markers ++ label('bookmark', if(bookmarks, '(' ++ bookmarks.join(', ') ++ ') ', '')) ++ if(description, truncate_end(30, description.first_line(), '…') ++ ' ', if(empty, label('empty_clean', '(empty) '), label('empty', '(no desc) '))) ++ label('timestamp', '(' ++ committer.timestamp().ago() ++ ') ') ++ label('author', '<' ++ author.name() ++ '> ') ++ if(signature, label('signature', ' '), label('unsigned', ' '))"
+my_default_log = "change_id.shortest(8) ++ if(divergent, format_change_offset(self), '') ++ ' - ' ++ workspace_markers ++ label('bookmark', if(bookmarks, '(' ++ bookmarks.join(', ') ++ ') ', '')) ++ if(description, truncate_end(30, description.first_line(), '…') ++ ' ', if(empty, label('empty_clean', '(empty) '), label('empty', '(no desc) '))) ++ label('timestamp', '(' ++ committer.timestamp().ago() ++ ') ') ++ label('author', '<' ++ format_short_signature(author) ++ '> ') ++ if(signature, label('signature', ' '), label('unsigned', ' '))"
 
 [remotes.origin]
 auto-track-bookmarks = "glob:*"


### PR DESCRIPTION
Reorder config-file directives in ghostty to load omarchy theme first, ensuring custom color schemes take precedence over auto-generated defaults.

Also adds Rancher Desktop PATH configuration to fish shell setup.

