### PR TITLE
fix: update mouse copy behavior in tmux configuration

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -37,7 +37,7 @@ if-shell 'command -v wl-copy >/dev/null 2>&1' \
         \"set -g @copy_cmd 'xclip -in -selection clipboard'\" \
         \"set -g @copy_cmd 'pbcopy'\""
 bind -T copy-mode-vi y send-keys -X copy-pipe "#{@copy_cmd}"
-bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe "#{@copy_cmd}"
+bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "#{@copy_cmd}"
 
 bind p paste-buffer
 
@@ -65,6 +65,8 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'tmux-plugins/tmux-battery'
+
+set -g @yank_with_mouse off
 
 # catppuccin
 set -g @catppuccin_status_left_separator ""


### PR DESCRIPTION
- Change `MouseDragEnd1Pane` from `copy-pipe` to `copy-pipe-no-clear` to prevent cursor from jumping after selecting and copying text
- Disable mouse yank behavior by setting `@yank_with_mouse off`
