### PR TITLE
feat: migrate to 1password for ssh signing

### DIFF
--- a/dot-local/bin/ssh-sign-wrapper.sh
+++ b/dot-local/bin/ssh-sign-wrapper.sh
@@ -50,6 +50,7 @@ for ((i=0; i<${#args[@]}; i++)); do
       tmp_pub="${TMPDIR:-/tmp}/ssh-sign-pub-$$.pub"
       printf '%s\n' "$val" > "$tmp_pub"
       pub_source="$tmp_pub"
+      args[i+1]="$tmp_pub"
       log "Converted inline pubkey to temp file: $tmp_pub"
     fi
 
@@ -114,7 +115,7 @@ ensure_loaded() {
 # Helper: ensure an SSH agent is available (does not guarantee keys are loaded)
 ensure_agent_and_keys() {
   # If using 1Password explicitly, do nothing here
-  [[ -n "${USE_1PASSWORD_SSH:-}" ]] && return 0
+  [[ "${USE_1PASSWORD_SSH:-}" == "1" ]] && return 0
 
   # If a 1Password socket is present but not opted in, ignore it
   if [[ "${SSH_AUTH_SOCK:-}" == *"/.1password/agent.sock" ]]; then
@@ -157,7 +158,7 @@ ensure_agent_and_keys() {
 }
 
 # Choose signer: default to system ssh-keygen (agent-backed), 1Password only if requested
-if [[ -n "${USE_1PASSWORD_SSH:-}" ]]; then
+if [[ "${USE_1PASSWORD_SSH:-}" == "1" ]]; then
   log "Using 1Password SSH agent (op-ssh-sign)"
   exec "$OPSIGN" "${args[@]}"
 else

--- a/dot-ssh/config
+++ b/dot-ssh/config
@@ -3,6 +3,9 @@
 # Default: use system ssh-agent everywhere; use macOS Keychain when available.
 # Linux safely ignores UseKeychain via IgnoreUnknown.
 
+Host github.com
+  IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+
 Host *
   IgnoreUnknown UseKeychain
   AddKeysToAgent yes

--- a/fish/conf.d/00-env.fish
+++ b/fish/conf.d/00-env.fish
@@ -27,9 +27,14 @@ set -gx TRY_PATH $HOME/Documents/code/tries
 # Homebrew auto-update (4 hours)
 set -gx HOMEBREW_AUTO_UPDATE_SECS (math 4 \* 60 \* 60)
 
-# SSH agent (1Password) - optional via USE_1PASSWORD_SSH
-if set -q USE_1PASSWORD_SSH
-    set -gx SSH_AUTH_SOCK ~/.1password/agent.sock
+# SSH signing (1Password); SSH auth stays scoped by ~/.ssh/config.
+if not set -q USE_1PASSWORD_SSH
+    set -gx USE_1PASSWORD_SSH 1
+end
+if test "$USE_1PASSWORD_SSH" = "1"
+    if type -q op; and not test -f $HOME/.ssh/allowed_signers
+        op item get --vault Private "GitHub Signing" --fields email,public_key | sed 's/,/ /' >$HOME/.ssh/allowed_signers
+    end
 else
     # Guardrail: if a lingering 1Password socket is set as a universal/parent var, clear it
     if set -q SSH_AUTH_SOCK; and string match -q '*/.1password/agent.sock' -- $SSH_AUTH_SOCK

--- a/git/config
+++ b/git/config
@@ -24,7 +24,7 @@
   program = "~/.local/bin/ssh-sign-wrapper.sh"
 	allowedSignersFile = "~/.ssh/allowed_signers"
 [user]
-	signingkey = "~/.ssh/id_ed25519_GitHubSigning.pub"
+  signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEue29p9rw3Auo+JQVEHydzJyEsMir+EFKQVn7b2qX03
 [include]
     path = ~/.gitlocal
 [filter "lfs"]

--- a/jj/config.toml
+++ b/jj/config.toml
@@ -147,7 +147,7 @@ committer = "#94e2d5"
 
 [signing]
 behavior = "own"
-key = "~/.ssh/id_ed25519_GitHubSigning.pub"
+key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEue29p9rw3Auo+JQVEHydzJyEsMir+EFKQVn7b2qX03"
 backend = "ssh"
 
 [core]

--- a/zsh/dot-zshrc
+++ b/zsh/dot-zshrc
@@ -131,9 +131,10 @@ function ignore {
     done
 }
 
-# Optional: use 1Password SSH agent when explicitly enabled
-if [[ -n "${USE_1PASSWORD_SSH:-}" ]]; then
-  export SSH_AUTH_SOCK=~/.1password/agent.sock
+# Use 1Password for SSH signing; SSH auth stays scoped by ~/.ssh/config.
+: "${USE_1PASSWORD_SSH:=1}"
+export USE_1PASSWORD_SSH
+if [[ "${USE_1PASSWORD_SSH}" == "1" ]]; then
   if type op >/dev/null 2>&1 && [[ ! -f $HOME/.ssh/allowed_signers ]]; then
     op item get --vault Private "GitHub Signing" --fields email,public_key | sed 's/,/ /' > $HOME/.ssh/allowed_signers
   fi


### PR DESCRIPTION
## Changes
- Configure 1Password SSH agent as default signer for git and jujutsu commits
- Update SSH config to use 1Password agent for GitHub authentication
- Fix ssh-sign-wrapper.sh to properly handle 1Password flag checks and pubkey argument passing
- Update git config with public key fingerprint instead of file path
- Update jj config with public key fingerprint instead of file path
- Standardize USE_1PASSWORD_SSH environment variable handling across shell configs (zsh, fish)

## Details
- Enables 1Password SSH signing by default (USE_1PASSWORD_SSH=1)
- SSH authentication remains scoped via ~/.ssh/config (IdentityAgent per-host)
- Automatically syncs allowed_signers from 1Password "GitHub Signing" item when needed
- Maintains backward compatibility with system ssh-agent fallback when 1Password is unavailable
```
