### PR TITLE
feat: add neojjit plugin with keybinding

### DIFF
--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -77,7 +77,7 @@ if not vim.g.vscode and JJ_exists() then
   map("n", "<leader>jf", picker.file_history, { desc = "JJ file history" })
   map("n", "<leader>jd", diff.open_vdiff, { desc = "JJ diff current buffer" })
 
-  map("n", "<leader>jj", function()
+  map("n", "<leader>jl", function()
     cmd.log({ summary = false })
   end, { desc = "JJ log" })
 

--- a/nvim/lua/plugins/jj.lua
+++ b/nvim/lua/plugins/jj.lua
@@ -14,6 +14,19 @@ end
 
 return {
   {
+    "JulianNymark/neojjit",
+    keys = {
+      {
+        "<leader>jj",
+        function()
+          require("neojjit").open()
+        end,
+        desc = "Neojjit",
+      },
+    },
+  },
+
+  {
     "folke/which-key.nvim",
     opts = function(_, opts)
       if not JJ_exists() then
@@ -22,7 +35,7 @@ return {
       opts.spec = opts.spec or {}
       vim.list_extend(opts.spec, {
         { "<leader>j", group = "JJ VCS", icon = "" },
-        { "<leader>jj", icon = { icon = "", color = "azure" } },
+        { "<leader>jl", icon = { icon = "", color = "azure" } },
         { "<leader>jL", icon = { icon = "", color = "blue" } },
         { "<leader>jt", icon = { icon = "󰓂", color = "cyan" } },
         { "<leader>jT", icon = { icon = "󰓂", color = "cyan" } },

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -37,7 +37,7 @@ if-shell 'command -v wl-copy >/dev/null 2>&1' \
         \"set -g @copy_cmd 'xclip -in -selection clipboard'\" \
         \"set -g @copy_cmd 'pbcopy'\""
 bind -T copy-mode-vi y send-keys -X copy-pipe "#{@copy_cmd}"
-bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe "#{@copy_cmd}"
+bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "#{@copy_cmd}"
 
 bind p paste-buffer
 
@@ -65,6 +65,8 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'tmux-plugins/tmux-battery'
+
+set -g @yank_with_mouse off
 
 # catppuccin
 set -g @catppuccin_status_left_separator ""


### PR DESCRIPTION
Add neojjit plugin for interactive Jujutsu UI integration.

- Install neojjit plugin with `<leader>jj` keybinding
- Move JJ log command from `<leader>jj` to `<leader>jl`
- Update which-key spec to reflect new keybinding assignment

