### PR TITLE
feat: reorganize tmux config and restore default prefix

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,28 +1,17 @@
 # for wsl
 set -sg escape-time 0
-
-unbind C-b
-bind-key C-a send-prefix
-set-option -g prefix C-a
 set -g focus-events on
 set -g detach-on-destroy off     # don't exit from tmux when closing a session
 set -g history-limit 1000000     # increase history size (from 2,000)
 
-# split panes using | and -
+# defaults, just ensuring the current path is copied
+bind  c  new-window      -c "#{pane_current_path}"
+bind  %  split-window -h -c "#{pane_current_path}" # because % is in the middle horizontally
+bind '"' split-window -v -c "#{pane_current_path}" # because " is in the middle vertically
+
+# Also allow split panes using | and -
 bind | split-window -h -c "#{pane_current_path}"
 bind - split-window -v -c "#{pane_current_path}"
-
-bind  c  new-window      -c "#{pane_current_path}"
-bind  %  split-window -h -c "#{pane_current_path}"
-bind '"' split-window -v -c "#{pane_current_path}"
-
-set-environment -gF TMUX_PLUGIN_MANAGER_PATH '#{HOME}/.local/share/tmux/plugins'
-
-if 'test ! -d "${TMUX_PLUGIN_MANAGER_PATH}/tpm"' {
-  run 'mkdir -p "${TMUX_PLUGIN_MANAGER_PATH}"'
-  run 'git clone https://github.com/tmux-plugins/tpm "${TMUX_PLUGIN_MANAGER_PATH}/tpm"'
-  run '${TMUX_PLUGIN_MANAGER_PATH}/tpm/bin/install_plugins'
-}
 
 # reload config file (change file location to your the tmux.conf you want to use)
 bind r source-file ~/.config/tmux/tmux.conf
@@ -47,17 +36,26 @@ bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
 
-bind-key -n C-f run-shell "tmux neww ~/.local/bin/tmux-sessionizer"
-bind-key O run-shell "tmux neww ~/.local/bin/tmux-sessionizer --all"
-
+# merge
 bind-key m choose-window -F "#{window_index}: #{window_name}" "join-pane -h -t %%"
 bind-key M choose-window -F "#{window_index}: #{window_name}" "join-pane -v -t %%"
+
+# sessions
+bind-key -n C-f run-shell "tmux neww ~/.local/bin/tmux-sessionizer"
+bind-key O run-shell "tmux neww ~/.local/bin/tmux-sessionizer --all"
 
 bind-key -r D run-shell "~/.local/bin/tmux-sessionizer ~/.dotfiles"
 bind-key -r C run-shell "~/.local/bin/tmux-sessionizer ~/Documents/code"
 bind-key -r V run-shell "~/.local/bin/tmux-sessionizer ~/Documents/Vault"
 
 # =============== Begin Plugins here ===============
+set-environment -gF TMUX_PLUGIN_MANAGER_PATH '#{HOME}/.local/share/tmux/plugins'
+if 'test ! -d "${TMUX_PLUGIN_MANAGER_PATH}/tpm"' {
+  run 'mkdir -p "${TMUX_PLUGIN_MANAGER_PATH}"'
+  run 'git clone https://github.com/tmux-plugins/tpm "${TMUX_PLUGIN_MANAGER_PATH}/tpm"'
+  run '${TMUX_PLUGIN_MANAGER_PATH}/tpm/bin/install_plugins'
+}
+
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'catppuccin/tmux#v2.1.3'
 set -g @plugin 'tmux-plugins/tmux-yank'
@@ -65,8 +63,6 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'tmux-plugins/tmux-battery'
-
-set -g @yank_with_mouse off
 
 # catppuccin
 set -g @catppuccin_status_left_separator ""

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -4,6 +4,10 @@ set -g focus-events on
 set -g detach-on-destroy off     # don't exit from tmux when closing a session
 set -g history-limit 1000000     # increase history size (from 2,000)
 
+# Because muscle memory
+bind-key C-a send-prefix
+set-option -g prefix C-a
+
 # defaults, just ensuring the current path is copied
 bind  c  new-window      -c "#{pane_current_path}"
 bind  %  split-window -h -c "#{pane_current_path}" # because % is in the middle horizontally


### PR DESCRIPTION
Reorganize tmux.conf for better maintainability:

- Remove custom C-a prefix binding and restore tmux default (C-b)
- Consolidate default keybindings (c, %, ") with path preservation at top
- Group related bindings: merge operations, session management
- Move plugin manager initialization before plugin declarations
- Remove unused `@yank_with_mouse off` setting

Changes improve config readability by grouping functionality logically while restoring standard tmux defaults.
