### PR TITLE
feat: show battery capacity while charging

### DIFF
--- a/waybar/config.jsonc
+++ b/waybar/config.jsonc
@@ -142,7 +142,8 @@
   "battery": {
     "format": "{capacity}% {icon}",
     "format-discharging": "{icon} {capacity}%",
-    "format-charging": "{icon}",
+    "format-charging": "{icon} {capacity}%",
+    "format-charged": "{icon}",
     "format-plugged": "",
     "format-icons": {
       "charging": [


### PR DESCRIPTION
Show battery capacity percentage in the charging format string so users can see charge level while plugged in.

The `format-charging` previously only showed the charging icon (e.g. ⚡). Now it also displays `{capacity}%`. The `format-charged` string was added to preserve the original icon-only display for the fully-charged state.
