### PR TITLE
feat: swap herdr install to self-maintained script

### DIFF
--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -11,7 +11,7 @@ name = "terminal"
 auto_switch = false
 
 [ui]
-pane_gaps = false
+pane_gaps = true
 show_agent_labels_on_pane_borders = true
 
 [keys]

--- a/install.sh
+++ b/install.sh
@@ -189,7 +189,10 @@ fi
 chsh -s "$(which fish)"
 
 echo Getting the nice to haves...
-brew install dust eza fd uutils-coreutils danielgatis/imgcat/imgcat herdr
+brew install dust eza fd uutils-coreutils danielgatis/imgcat/imgcat
+
+echo Installing Herdr...
+curl -fsSL https://herdr.dev/install.sh | sh
 
 if command -v herdr >/dev/null 2>&1; then
   herdr integration install claude


### PR DESCRIPTION
Replace Homebrew-managed herdr with the self-maintained install script
 and enable pane gaps in the herdr UI config (`pane_gaps = true`).
