### PR TITLE
feat: add hunk pager with config and update-skills script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ nvim/spell/languagetool_dictionary_personal.csv
 tmux/plugins/
 zed/conversations/
 zed/prompts/
+hunk/state.json

--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ stow -v2 -t ~/.config/opencode ai
 superclaude mcp --list
 superclaude mcp
 
+# Update agent skills/plugins
+update-skills.sh
+# Optional: TEACH_SKILL_SOURCE=owner/repo update-skills.sh
+
 # Verify
 superclaude install --list
 superclaude doctor

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -11,7 +11,7 @@ name = "terminal"
 auto_switch = false
 
 [ui]
-pane_gaps = false
+pane_gaps = true
 show_agent_labels_on_pane_borders = true
 
 [keys]

--- a/hunk/config.toml
+++ b/hunk/config.toml
@@ -1,0 +1,10 @@
+theme = "catppuccin-mocha"
+mode = "auto"
+vcs = "jj"
+watch = false
+exclude_untracked = false
+line_numbers = true
+wrap_lines = false
+menu_bar = true
+agent_notes = true
+transparent_background = true

--- a/install.sh
+++ b/install.sh
@@ -189,7 +189,10 @@ fi
 chsh -s "$(which fish)"
 
 echo Getting the nice to haves...
-brew install dust eza fd uutils-coreutils danielgatis/imgcat/imgcat herdr
+brew install dust eza fd uutils-coreutils danielgatis/imgcat/imgcat
+
+echo Installing Herdr...
+curl -fsSL https://herdr.dev/install.sh | sh
 
 if command -v herdr >/dev/null 2>&1; then
   herdr integration install claude

--- a/install.sh
+++ b/install.sh
@@ -189,7 +189,7 @@ fi
 chsh -s "$(which fish)"
 
 echo Getting the nice to haves...
-brew install dust eza fd uutils-coreutils danielgatis/imgcat/imgcat
+brew install dust eza fd uutils-coreutils danielgatis/imgcat/imgcat hunk
 
 echo Installing Herdr...
 curl -fsSL https://herdr.dev/install.sh | sh

--- a/jj/config.toml
+++ b/jj/config.toml
@@ -32,13 +32,14 @@ log = "latest(curbranch::@, 30) | @::nextbranch | @ | @- | children(@) | ancesto
 'other_branches_summary()' = "ancestors(other_feature_branches(), 4) | descendants(other_feature_branches())"
 
 [aliases]
-my_log = ["log", "-T", "my_default_log"]
+my_log = ["log", "-T", "my_default_log", "--no-pager"]
 l = [
   "log",
   "-r",
   "latest(@ | ancestors(bookmarks(), 3) | ancestors(@, 15) | ancestors(trunk() | main, 3) | @::, 30)",
 ]
-s = ["status"]
+s = ["status", "--no-pager"]
+st = ["status", "--no-pager"]
 retrunk = ["rebase", "-d", "trunk()"]
 lr = ["log", "-r", "recent()"]
 e = ["edit"]
@@ -97,7 +98,7 @@ push = [
 sign = true
 
 [ui]
-pager = "cat"
+pager = ["hunk", "pager"]
 default-command = ["my_log"]
 diff-editor = "nvim"
 diff-formatter = ":git"

--- a/update-skills.sh
+++ b/update-skills.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -u
+
+failures=0
+
+have() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+step() {
+  printf '\n==> %s\n' "$*"
+}
+
+try() {
+  step "$*"
+  if "$@"; then
+    return 0
+  fi
+
+  failures=$((failures + 1))
+  printf 'warn: failed: %s\n' "$*" >&2
+  return 1
+}
+
+try_quiet() {
+  "$@" >/dev/null 2>&1
+}
+
+install_superclaude() {
+  if have pipx; then
+    if pipx list --short 2>/dev/null | awk '{print $1}' | grep -qx superclaude; then
+      try pipx upgrade superclaude || true
+    else
+      try pipx install superclaude || true
+    fi
+  fi
+
+  if have superclaude; then
+    try superclaude install || true
+    try superclaude install --list || true
+    try superclaude doctor || true
+  else
+    failures=$((failures + 1))
+    printf 'warn: superclaude not found; install pipx or add ~/.local/bin to PATH\n' >&2
+  fi
+}
+
+install_ponytail() {
+  local marketplace="${PONYTAIL_MARKETPLACE:-DietrichGebert/ponytail}"
+
+  if have claude; then
+    try_quiet claude plugin marketplace add "$marketplace" || true
+    try claude plugin marketplace update ponytail || true
+    if claude plugin list 2>/dev/null | grep -q 'ponytail@ponytail'; then
+      try claude plugin update ponytail@ponytail || true
+    else
+      try claude plugin install ponytail@ponytail || true
+    fi
+  fi
+
+  if have codex; then
+    try_quiet codex plugin marketplace add "$marketplace" || true
+    try codex plugin marketplace upgrade ponytail || true
+    if codex plugin list 2>/dev/null | grep -q 'ponytail@ponytail.*installed'; then
+      step "codex ponytail already installed"
+    else
+      try codex plugin add ponytail@ponytail || true
+    fi
+  fi
+
+  if have opencode; then
+    try opencode plugin --global --force @dietrichgebert/ponytail || true
+  fi
+}
+
+install_hunk() {
+  local source="${HUNK_SKILL_SOURCE:-modem-dev/hunk}"
+
+  if have brew; then
+    step "brew install/upgrade hunk"
+    brew install hunk || brew upgrade hunk || {
+      failures=$((failures + 1))
+      printf 'warn: failed: brew install/upgrade hunk\n' >&2
+    }
+  fi
+
+  if have npx; then
+    try npx -y skills add "$source" --skill hunk-review -g -a claude-code -a codex -a opencode -y || true
+  else
+    failures=$((failures + 1))
+    printf 'warn: npx not found; cannot install hunk skill from %s\n' "$source" >&2
+  fi
+}
+
+install_teach() {
+  if [[ -z "${TEACH_SKILL_SOURCE:-}" ]]; then
+    if [[ -d "$HOME/.claude/skills/teach" ]]; then
+      step "install teach from existing Claude skill"
+      mkdir -p "$HOME/.agents/skills"
+      rm -rf "$HOME/.agents/skills/teach"
+      cp -pR "$HOME/.claude/skills/teach" "$HOME/.agents/skills/teach"
+      mkdir -p "$HOME/.codex/skills"
+      ln -sfn ../../.agents/skills/teach "$HOME/.codex/skills/teach"
+      return 0
+    fi
+
+    printf '\n==> teach skill skipped\n'
+    printf 'set TEACH_SKILL_SOURCE=owner/repo or owner/repo/path, or install ~/.claude/skills/teach first\n'
+    return 0
+  fi
+
+  if have npx; then
+    try npx -y skills add "$TEACH_SKILL_SOURCE" --skill teach -g -a claude-code -a codex -a opencode -y || true
+  else
+    failures=$((failures + 1))
+    printf 'warn: npx not found; cannot install teach skill from %s\n' "$TEACH_SKILL_SOURCE" >&2
+  fi
+}
+
+install_superclaude
+install_ponytail
+install_hunk
+install_teach
+
+if [[ "$failures" -gt 0 ]]; then
+  printf '\nDone with %s warning(s). Restart agents to pick up skill/plugin changes.\n' "$failures" >&2
+  exit 1
+fi
+
+printf '\nDone. Restart agents to pick up skill/plugin changes.\n'


### PR DESCRIPTION
Replace `cat` as the jj pager with `hunk`, a modern terminal pager. Config uses
catppuccin-mocha theme and jj VCS mode.

- **hunk/config.toml** — new pager config (catppuccin-mocha, auto mode, jj VCS)
- **jj/config.toml** — set pager to `["hunk", "pager"]`, add `--no-pager` to
  `my_log` and `status` aliases, add `st` alias
- **install.sh** — add `hunk` to brew installs
- **.gitignore** — ignore `hunk/state.json`
- **update-skills.sh** — new script: install/upgrade superclaude, ponytail,
  hunk skills, and teach skill for claude/codex/opencode
- **README.md** — document `update-skills.sh` usage
