### PR TITLE
feat: add lazyjj configuration

### DIFF
--- a/fish/functions/bookmark.fish
+++ b/fish/functions/bookmark.fish
@@ -6,6 +6,6 @@ function bookmark
     end
 
     if jj workspace root >/dev/null 2>&1
-        jj log -r 'closest_bookmark(@)' -T 'bookmarks.map(|b| b.name())' -G
+        jj ghbranch
     end
 end

--- a/fish/functions/ghprs.fish
+++ b/fish/functions/ghprs.fish
@@ -1,0 +1,63 @@
+# Create stacked GitHub PRs: push the whole stack once, then run ghpr per
+# bookmark bottom-to-top. Reuses ghpr for each PR (AI title/body, auto base
+# detection, existing-PR skip). jj-only — in git repos just use ghpr.
+#
+# Flags:
+#   -d/--draft, -l/--label  → applied to every PR in the stack
+#   -B/--base <ref>         → base for the BOTTOM PR only; the rest stack on
+#                             their parent bookmark as usual
+#   --dry-run               → preview every PR, create nothing
+# -t/--title and -r/--revision are rejected: they're per-PR and would clobber
+# the whole stack (title should be AI-generated per PR; -r conflicts with -b).
+
+function ghprs --description "Create stacked GitHub PRs with AI bodies via ghpr"
+    if not type -q jj; or not jj workspace root >/dev/null 2>&1
+        echo "Error: ghprs is jj-only. Use ghpr in git repos."
+        return 1
+    end
+
+    argparse d/draft dry-run 'B/base=' 't/title=' 'b/bookmark=' 'r/revision=' 'l/label=' -- $argv
+    or return 1
+
+    if set -q _flag_title; or set -q _flag_revision; or set -q _flag_bookmark
+        echo "Error: -t/--title, -r/--revision, -b/--bookmark are per-PR and break a stack."
+        echo "  Titles are AI-generated per PR. Base the bottom PR with -B; the rest auto-stack."
+        return 1
+    end
+
+    # ghpr requires bookmarks already on origin — push the whole stack first
+    echo "✓ Pushing stack..."
+    if not jj ss
+        echo "✗ Stack push failed"
+        return 1
+    end
+
+    # Bottom-to-top so each PR's parent bookmark already exists as a base.
+    # jj pr-stack emits bookmark names (its template); strip trailing * and trunk.
+    set -l bookmarks (jj pr-stack --reversed --no-graph 2>/dev/null \
+        | string replace -r '\*$' '' | string trim | string match -rv '^(main|master)?$')
+
+    if test (count $bookmarks) -eq 0
+        echo "Error: No stack bookmarks found. Create one with: jj create <name>"
+        return 1
+    end
+
+    # Flags that apply to every PR
+    set -l common
+    set -q _flag_draft; and set -a common --draft
+    set -q _flag_dry_run; and set -a common --dry-run
+    set -q _flag_label; and set -a common --label $_flag_label
+
+    echo "✓ "(count $bookmarks)" bookmark(s) in stack"
+    for i in (seq (count $bookmarks))
+        set -l bm $bookmarks[$i]
+        echo ""
+        echo "━━━ PR for $bm ━━━"
+        set -l args -b $bm $common
+        # -B overrides the bottom PR's base only; upper PRs auto-detect parent
+        if test $i -eq 1; and set -q _flag_base
+            set args $args -B $_flag_base
+        end
+        ghpr $args
+    end
+end

--- a/jj/conf.d/lazyjj-aliases.toml
+++ b/jj/conf.d/lazyjj-aliases.toml
@@ -1,1 +1,26 @@
-/Users/brad.robinson/.config/jj/lazyjj/config/lazyjj-aliases.toml
+# LazyJJ Core Aliases
+# https://lazyjj.dev
+#
+# Aliases that add value beyond built-in JJ commands.
+# For shortcuts, see lazyjj-shortcuts.toml.
+
+[aliases]
+
+# diff-summary - Compact diff summary without pager
+# What: Shows a one-line-per-file summary of changes (Added/Modified/Deleted).
+# When: Use for a quick overview of which files changed, without line details.
+# Usage: jj diff-summary
+diff-summary = ["diff", "--summary", "--no-pager"]
+
+# diff-files - List changed filenames only
+# What: Outputs just the names of changed files, one per line.
+# When: Useful for scripting or piping to other commands.
+# Usage: jj diff-files
+#        jj diff-files | xargs nvim
+diff-files = ["diff", "--name-only", "--no-pager"]
+
+# log-short - Quick log (last 10 commits)
+# What: Shows the 10 most recent commits in the log.
+# When: Use for a quick glance at recent history without scrolling.
+# Usage: jj log-short
+log-short = ["log", "--limit", "10"]

--- a/jj/conf.d/lazyjj-aliases.toml
+++ b/jj/conf.d/lazyjj-aliases.toml
@@ -1,0 +1,1 @@
+/Users/brad.robinson/.config/jj/lazyjj/config/lazyjj-aliases.toml

--- a/jj/conf.d/lazyjj-claude.toml
+++ b/jj/conf.d/lazyjj-claude.toml
@@ -1,1 +1,40 @@
-/Users/brad.robinson/.config/jj/lazyjj/config/lazyjj-claude.toml
+# LazyJJ Claude Integration
+# https://lazyjj.dev
+#
+# Trimmed from upstream. Workspace management (claude-start/stop) removed —
+# herdr (jj-workspace plugin, prefix+a/prefix+d) owns workspace-per-agent now.
+# claude-checkpoint removed — builtin `jj commit -m "msg"` already does
+# describe-@ + new-child. Only the conflict-resolve helper remains.
+#
+# Requires: claude CLI (https://claude.ai/code)
+
+[aliases]
+
+# claude-resolve - Resolve conflicts using Claude
+# What: Creates a new commit and launches Claude to help resolve conflicts.
+# When: Use after a rebase or merge that resulted in conflicts.
+# Usage: jj claude-resolve          # resolve conflicts in parent (@-)
+#        jj claude-resolve <rev>    # resolve conflicts in specific revision
+#
+# How it works:
+#   1. Takes optional revision argument (defaults to @-)
+#   2. Creates new commit based on that revision
+#   3. Lists all conflicted files in parent revision
+#   4. Launches Claude in plan mode with all conflicts at once
+#   5. Provides helpful JJ commands for investigating conflict history
+claude-resolve = [
+  "util",
+  "exec",
+  "--",
+  "bash",
+  "-c",
+  """
+  set -euo pipefail
+  revision=${1:-@-}
+  if [ "$#" -eq 1 ]; then
+    jj new $revision
+  fi
+  echo "Resolving conflicts in $revision"
+  claude --permission-mode=plan "resolve conflicts in $(jj resolve -r @- --list | awk '{print \"@\"$1}' | paste -sd' ' -). You can look for recent changes to the conflicted files with 'jj log -r \\\"latest(..@ & files({file}))\\\" -s' and check the actual changes with 'jj show {change_id}'"
+""",
+  "",]

--- a/jj/conf.d/lazyjj-claude.toml
+++ b/jj/conf.d/lazyjj-claude.toml
@@ -1,0 +1,1 @@
+/Users/brad.robinson/.config/jj/lazyjj/config/lazyjj-claude.toml

--- a/jj/conf.d/lazyjj-github.toml
+++ b/jj/conf.d/lazyjj-github.toml
@@ -1,1 +1,220 @@
-/Users/brad.robinson/.config/jj/lazyjj/config/lazyjj-github.toml
+# LazyJJ GitHub Integration
+# https://lazyjj.dev
+#
+# Commands for working with GitHub PRs, including stacked PRs workflow.
+# Requires: gh CLI (https://cli.github.com)
+#
+# Stacked PRs Workflow:
+#   1. Create multiple commits in your stack, each with a bookmark
+#   2. jj pr-stack-create    - Create/update PRs for each bookmark
+#   3. jj pr-stack-summary     - Generate a summary of the stack
+#   4. jj pr-stack-update    - Update PR comments with the stack summary
+
+[revset-aliases]
+ghbranch = "heads(::@ & bookmarks())"
+
+[aliases]
+
+# =============================================================================
+# REPOSITORY HELPERS
+# =============================================================================
+
+# github-repo - Get the GitHub repo name from origin remote
+# What: Extracts owner/repo from the origin remote URL (e.g., "owner/repo").
+# When: Used internally by other GitHub commands to target the right repo.
+# Usage: jj github-repo
+#        # Output: "lazyjj-dev/lazyjj"
+github-repo = ["util", "exec", "--", "bash", "-c", """
+  jj git remote list | rg '^origin .*github.com[:/](.*)$' -o -r '$1' | sed -e 's/.git$//'
+  """, ""]
+
+# gh - Run GitHub CLI command
+# What: Wrapper for `gh` CLI.
+# When: Use to run any gh command.
+# Usage: jj gh pr list
+#        jj gh issue view 123
+gh = ["util", "exec", "--", "bash", "-c", """
+  gh $@ -R $(jj github-repo)
+  """, ""]
+
+# =============================================================================
+# PULL REQUEST VIEWING
+# =============================================================================
+
+# pr-view - View current PR details
+# What: Shows details of the PR for the current bookmark.
+# When: Use to check PR status, reviews, and checks.
+# Usage: jj pr-view
+pr-view = ["util", "exec", "--", "bash", "-c", """
+  set -e
+  branch=$(jj ghbranch)
+  jj gh pr view "$branch" "$@"
+  """, ""]
+
+# pr-open - Open current PR in browser
+# What: Opens the PR for current bookmark in your default browser.
+# When: Use to quickly jump to the PR on GitHub.
+# Usage: jj pr-open
+pr-open = ["pr-view", "-w"]
+
+# =============================================================================
+# STACKED PRS
+# =============================================================================
+
+# pr-stack - List all bookmarks in the current stack
+# What: Lists bookmark names in your stack.
+# When: Use to see which PRs are in your current stack.
+# Usage: jj pr-stack
+pr-stack = [
+  "log",
+  "-r",
+  "stack- & mutable() & bookmarks() | trunk()",
+  "-T",
+  "bookmarks.map(|c| c.name()) ++ '\n'",
+  "--no-pager",
+]
+
+# pr-stack-create - Create or update stacked PRs
+# What: For each bookmark in the stack, pushes and creates a PR if needed.
+#       Each PR's base is set to the previous bookmark (or main for the first).
+# When: Use after pushing your stack to create/update the PR chain.
+# Usage: jj pr-stack-create
+pr-stack-create = ["util", "exec", "--", "bash", "-c", """
+  set -e
+  while read -r bm; do
+    bm_branch=${bm%\\*}
+    base_bm=$(jj log -r "stack- & bookmarks() & heads(::bookmarks(exact:'$bm_branch')- & bookmarks())" -T 'bookmarks' --no-graph --no-pager)
+    base_branch=${base_bm%\\*}
+    jj gh pr edit "$bm_branch" --base "$base_branch" || \
+      jj gh pr create --head "$bm_branch" --base "$base_branch" -w
+  done < <(jj pr-stack --reversed --no-graph | rg -v '^main$')
+  """, ""]
+
+# pr-stack-summary - Generate PR stack summary
+# What: Creates a text summary of all PRs in the stack with links.
+# When: Use to generate content for PR descriptions or Slack updates.
+# Usage: jj pr-stack-summary
+#        # Output:
+#        # ## PR Stack
+#        # - [feature-a](https://github.com/.../1): First feature
+#        # - [feature-b](https://github.com/.../2): Second feature
+pr-stack-summary = ["util", "exec", "--", "bash", "-c", """
+  set -e
+  echo "## PR Stack"
+  echo ""
+  # List bookmarks in reverse order (oldest first)
+  while read -r bm; do
+    bm_branch=${bm%\\*}
+    PR_URL=$(jj gh pr view "$bm_branch" --json url -q '.url' 2>/dev/null || echo "no PR")
+    DESC=$(jj log -r "$bm_branch" --no-graph -T 'description.first_line()' | head -1)
+    echo "- [$bm_branch]($PR_URL): $DESC"
+  done < <(jj pr-stack --reversed --no-graph | rg -v '^main$' | tac)
+  """, ""]
+
+# pr-stack-update - Update all PR comments with stack summary
+# What: Adds/updates a comment on each PR in the stack showing the full stack.
+# When: Use to keep PR comments updated with the current stack status.
+# Usage: jj pr-stack-update
+pr-stack-update = ["util", "exec", "--", "bash", "-c", """
+  set -e
+  comment=$(jj pr-stack-summary)
+  while read -r bm; do
+    bm_branch=${bm%\\*}
+    printf '%s\n' "$comment" | \
+      jj gh pr comment --edit-last --create-if-none -F - "$bm_branch"
+  done < <(jj pr-stack --reversed --no-graph | rg -v '^main$')
+  """, ""]
+
+# =============================================================================
+# PR FORMATTING (Enhanced)
+# =============================================================================
+
+# _format_pr - Internal helper to format a single PR with detailed status
+# What: Formats a PR with CI status, review status, number, and title.
+# When: Used internally by pr-stack-format and pr-stacks-format.
+# Usage: jj _format_pr <bookmark>
+#
+# Status indicators:
+#   CI: 🔴 (failed), ⏱️ (in progress), 🟢 (passed)
+#   Review: 🏗️ (draft), ⏳ (needs review), ✅ (approved), ✏️ (changes), 🛬 (merged)
+_format_pr = [
+  "util",
+  "--ignore-working-copy",
+  "exec",
+  "--",
+  "bash",
+  "-c",
+  """
+  set -e
+  bm_branch="$1"
+  prstatus=$(mktemp)
+  jj --ignore-working-copy gh pr view --json state,title,reviewDecision,isDraft,url,number,statusCheckRollup "$bm_branch" > $prstatus 2>/dev/null || exit 0
+  cat $prstatus | jq -r '
+    . as $pr |
+      "- " +
+(if ($pr.statusCheckRollup | length) > 0 then
+   if ($pr.statusCheckRollup | map(.conclusion) | index("FAILURE")) then
+     "🔴"
+   elif ($pr.statusCheckRollup | map(.status) | index("IN_PROGRESS")) then
+     "⏱️"
+   else "🟢" end
+ else "" end) +
+      (if $pr.isDraft then "🏗️"
+        elif $pr.state == "MERGED" then "🛬"
+        elif $pr.reviewDecision == "" then "⏳"
+        elif $pr.reviewDecision == "REVIEW_REQUIRED" then "⏳"
+        elif $pr.state == "OPEN" and $pr.reviewDecision == "APPROVED" then "✅"
+        elif $pr.state == "OPEN" and $pr.reviewDecision == "CHANGES_REQUESTED" then "✏️"
+        elif $pr.state == "OPEN" and $pr.reviewDecision != "" then $pr.reviewDecision
+        else "" end) +
+      " [#" + (.number | tostring) + "](" + .url + ") " + .title
+    '
+  """,
+  "",
+]
+
+# pr-stack-format - Format current stack PRs for Slack/Markdown
+# What: Generates markdown-formatted status for all PRs in current stack.
+# When: Use to share detailed stack status with CI and review info.
+# Usage: jj pr-stack-format | pbcopy
+#        # Then paste into Slack/GitHub
+pr-stack-md = [
+  "util",
+  "--ignore-working-copy",
+  "exec",
+  "--",
+  "bash",
+  "-c",
+  """
+  set -e
+  while read -r bm; do
+    bm_branch=${bm%\\*}
+    jj _format_pr "$bm_branch"
+  done < <(jj pr-stack --reversed --no-graph --ignore-working-copy | rg -v '^main$')
+  """,
+  "",
+]
+
+# pr-stacks-format - Format ALL mutable bookmarked PRs for Slack/Markdown
+# What: Generates markdown-formatted status for all mutable PRs in repo.
+# When: Use to get overview of all your PRs across all stacks.
+# Usage: jj pr-stacks-format | pbcopy
+pr-stacks-all-md = [
+  "util",
+  "--ignore-working-copy",
+  "exec",
+  "--",
+  "bash",
+  "-c",
+  """
+  set -e
+  while read -r bm; do
+    bm_branch=${bm%\\*}
+    if [ "$bm_branch" = "main" ]; then
+      continue
+    fi
+    jj _format_pr "$bm_branch"
+  done < <(jj log -r "mutable() & bookmarks()" -T "bookmarks.map(|c| c.name()) ++ '\n'" --no-pager --no-graph --ignore-working-copy)
+  """,
+  "",
+]

--- a/jj/conf.d/lazyjj-github.toml
+++ b/jj/conf.d/lazyjj-github.toml
@@ -1,0 +1,1 @@
+/Users/brad.robinson/.config/jj/lazyjj/config/lazyjj-github.toml

--- a/jj/conf.d/lazyjj-github.toml
+++ b/jj/conf.d/lazyjj-github.toml
@@ -15,6 +15,16 @@ ghbranch = "heads(::@ & bookmarks())"
 
 [aliases]
 
+# ghbranch - Print the bookmark name for the current position (command form)
+# What: Nearest non-trunk bookmark at/below @ (via our closest_bookmark alias),
+#       as a plain name. lazyjj's GitHub commands invoke `jj ghbranch` as a
+#       command, but it was only a revset-alias — this makes the command work.
+#       closest_bookmark excludes trunk, so it never resolves to main for a PR.
+#       --ignore-working-copy: pr-view runs this inside `jj util exec`; snapshot
+#       here would race the outer checkout (see stack-sync).
+# Usage: jj ghbranch   ->  feat/my-thing
+ghbranch = ["log", "-r", "closest_bookmark(@)", "-T", 'bookmarks.map(|b| b.name()).join(" ")', "-G", "--ignore-working-copy"]
+
 # =============================================================================
 # REPOSITORY HELPERS
 # =============================================================================

--- a/jj/conf.d/lazyjj-revsets.toml
+++ b/jj/conf.d/lazyjj-revsets.toml
@@ -1,0 +1,1 @@
+/Users/brad.robinson/.config/jj/lazyjj/config/lazyjj-revsets.toml

--- a/jj/conf.d/lazyjj-revsets.toml
+++ b/jj/conf.d/lazyjj-revsets.toml
@@ -1,1 +1,66 @@
-/Users/brad.robinson/.config/jj/lazyjj/config/lazyjj-revsets.toml
+# LazyJJ Revset Aliases
+# https://lazyjj.dev
+#
+# Revset aliases for common queries and stack-based workflows.
+#
+# A "stack" is the set of commits from where you branched off trunk
+# to your current position. These revsets help you query and navigate stacks.
+#
+# Visual representation:
+#
+#   trunk ─── A ─── B ─── C ─── @ (current)
+#             ↑                 ↑
+#        branch_off          head
+#             └─────────────────┘
+#                   stack
+
+[revset-aliases]
+
+# trunk - The main integration branch
+# What: Evaluates to the trunk() function, typically main/master.
+# When: Use to reference the main branch or as a base for rebasing.
+# Usage: jj log -r trunk
+#        jj rebase -d trunk
+"trunk" = "trunk()"
+
+# branch_off - Where your current work diverged from trunk
+# What: Finds the fork point between trunk and your current position.
+# When: Use to see where your stack began or to diff against.
+# Usage: jj log -r branch_off
+#        jj diff -f branch_off    # See all changes in your stack
+"branch_off" = "fork_point(trunk() | @)"
+
+# stack_base - Root commit(s) of your current stack
+# What: The first commit(s) after branch_off in your current path.
+# When: Use to identify where your stack starts.
+# Usage: jj log -r stack_base
+"stack_base" = "roots(branch_off+::@)"
+
+# stack - All commits in your current stack
+# What: Every commit from stack_base to the current position and beyond.
+# When: Use to view, rebase, or operate on your entire stack.
+# Usage: jj log -r stack
+#        jj log -r "stack & bookmarks()"   # Stack commits with bookmarks
+"stack" = "stack_base::"
+
+# stacks - All your work-in-progress commits
+# What: Mutable commits you authored that lead to a bookmark (real PR candidates),
+#       across the entire repo. Scoped to bookmarked work to cut noise;
+#       upstream lazyjj uses bare `mine() & mutable()` which floods with every
+#       loose draft + empty workspace commit. Empties left in — `jj gc` handles those.
+# When: Use to see all your unfinished work, not just the current stack.
+# Usage: jj log -r stacks
+"stacks" = "mine() & mutable() & (bookmarks() | ancestors(bookmarks()))"
+
+# no_description - Commits missing descriptions
+# What: Non-empty commits without a description (excluding root).
+# When: Use to find commits that need descriptions before pushing.
+# Usage: jj log -r no_description
+#        jj log -r "stack & no_description"
+"no_description" = "description(exact:'') ~ root() ~ empty()"
+
+# ghbranch - The bookmark (branch) for the current position
+# What: The most recent bookmark in the ancestry of current position.
+# When: Used internally by GitHub commands to find the PR branch.
+# Usage: jj log -r ghbranch
+"ghbranch" = "heads(::@ & bookmarks())"

--- a/jj/conf.d/lazyjj-self.toml
+++ b/jj/conf.d/lazyjj-self.toml
@@ -1,0 +1,1 @@
+/Users/brad.robinson/.config/jj/lazyjj/config/lazyjj-self.toml

--- a/jj/conf.d/lazyjj-self.toml
+++ b/jj/conf.d/lazyjj-self.toml
@@ -1,1 +1,0 @@
-/Users/brad.robinson/.config/jj/lazyjj/config/lazyjj-self.toml

--- a/jj/conf.d/lazyjj-shortcuts.toml
+++ b/jj/conf.d/lazyjj-shortcuts.toml
@@ -1,1 +1,50 @@
-/Users/brad.robinson/.config/jj/lazyjj/config/lazyjj-shortcuts.toml
+# LazyJJ Shortcuts
+# https://lazyjj.dev
+#
+# Short aliases for common commands.
+# These are provided for convenience - if you prefer explicit commands,
+# you can remove this file.
+
+[aliases]
+
+# =============================================================================
+# CORE SHORTCUTS
+# =============================================================================
+
+# Aliases with added value (shortcuts to lazyjj-aliases.toml commands)
+diffs = ["diff-summary"]
+diffls = ["diff-files"]
+gf = ["git", "fetch"]
+
+# =============================================================================
+# STACK SHORTCUTS (from lazyjj-stack.toml)
+# =============================================================================
+
+stack = ["stack-view"]
+stackls = ["stack-files"]
+stacks = ["stacks-all"]
+stacksls = ["stacks-all-files"]
+top = ["stack-top"]
+gc = ["stack-gc"]
+ss = ["stack-submit"]
+sync = ["stack-sync"]
+start = ["stack-start"]
+
+# =============================================================================
+# GITHUB SHORTCUTS (from lazyjj-github.toml)
+# =============================================================================
+
+repo = ["github-repo"]
+prv = ["pr-view"]
+pro = ["pr-open"]
+sprs = ["pr-stack-create"]
+prs = ["pr-stack-summary"]
+uprs = ["pr-stack-update"]
+prmd = ["pr-stack-md"]   # Deprecated, use prf/prfs
+
+# =============================================================================
+# CLAUDE SHORTCUTS (from lazyjj-claude.toml)
+# =============================================================================
+
+# clstart/clstop removed — herdr owns workspace management now.
+clresolve = ["claude-resolve"]

--- a/jj/conf.d/lazyjj-shortcuts.toml
+++ b/jj/conf.d/lazyjj-shortcuts.toml
@@ -1,0 +1,1 @@
+/Users/brad.robinson/.config/jj/lazyjj/config/lazyjj-shortcuts.toml

--- a/jj/conf.d/lazyjj-stack.toml
+++ b/jj/conf.d/lazyjj-stack.toml
@@ -1,1 +1,137 @@
-/Users/brad.robinson/.config/jj/lazyjj/config/lazyjj-stack.toml
+# LazyJJ Stack Workflow
+# https://lazyjj.dev
+#
+# Commands for working with stacks of commits.
+# A "stack" is the set of commits from where you branched off trunk to your current position.
+#
+# Stack Workflow Overview:
+#   1. jj stack-start         - Begin fresh work from trunk
+#   2. Make changes, jj new-commit, repeat
+#   3. jj create <name> - Create a bookmark for the PR
+#   4. jj stack-submit            - Push your stack to remote
+#   5. jj stack-sync          - Fetch updates and rebase your stack
+
+[aliases]
+
+# =============================================================================
+# VIEW STACKS
+# =============================================================================
+
+# stack-view - View your current stack of commits
+# What: Shows all commits in your stack along with trunk for context.
+# When: Use frequently to visualize your work and its relationship to trunk.
+# Usage: jj stack-view
+stack-view = ["log", "-r", "stack | trunk() | present(@)"]
+
+# stack-files - View stack with file changes listed
+# What: Shows stack commits with a summary of changed files per commit.
+# When: Use to see which files each commit in your stack touches.
+# Usage: jj stack-files
+stack-files = ["log", "-r", "trunk::stack", "-s"]
+
+# stacks-all - View all your work-in-progress stacks
+# What: Shows all mutable commits you've authored across all branches.
+# When: Use to see all your unfinished work, not just current stack.
+# Usage: jj stacks-all
+stacks-all = ["log", "-r", "stacks"]
+
+# stacks-all-files - View all stacks with file changes
+# What: Shows all your stacks with file change summaries.
+# When: Use to audit all your in-progress work with file details.
+# Usage: jj stacks-all-files
+stacks-all-files = ["log", "-r", "stacks", "-s"]
+
+# =============================================================================
+# NAVIGATE STACK
+# =============================================================================
+
+# stack-top - Jump to the top of your stack
+# What: Edits the head commit of your stack.
+# When: Use to return to the top after editing commits lower in the stack.
+# Usage: jj stack-top
+stack-top = ["new", "heads(stack)"]
+
+# =============================================================================
+# STACK MAINTENANCE
+# =============================================================================
+
+# stack-gc - Garbage collect empty commits in stack
+# What: Abandons empty commits in your stack.
+# When: Use after squashing or when empty commits accumulate.
+# Usage: jj stack-gc
+stack-gc = ["abandon", "empty() & stack"]
+
+# restack - Rebase your stack onto trunk
+# What: Rebases the entire current stack onto the latest trunk.
+# When: Use after fetching to integrate upstream changes.
+# Usage: jj restack
+restack = ["rebase", "-s", "stack_base", "-d", "trunk"]
+
+# restack-all - Rebase all stacks onto trunk
+# What: Rebases all mutable stacks you've authored onto the latest trunk.
+# When: Use to update all your in-progress work with upstream changes.
+# Usage: jj restack-all
+restack-all = ["rebase", "-b", "roots(stacks)", "-d", "trunk()", "--skip-emptied"]
+
+# =============================================================================
+# BOOKMARK MANAGEMENT
+# =============================================================================
+
+# bookmark-tug: intentionally omitted — config.toml `tug`/`tug-` (closest_pushable)
+# supersedes lazyjj's simpler @- version. See jj/config.toml.
+
+# bookmark-create - Create a new bookmark at @-
+# What: Creates a named bookmark pointing at your previous commit (@-).
+# When: Use to create a PR branch name for your work.
+# Usage: jj create my-feature
+#        jj create fix/bug-123
+create = ["bookmark", "create", "--to", "@-"]
+
+# =============================================================================
+# PUSH TO REMOTE
+# =============================================================================
+
+# stack-submit - Smart Stack push
+# What: Pushes all commits in your stack to remote, allowing new branches.
+# When: Use to push your stack for code review.
+# Usage: jj stack-submit
+stack-submit = ["git", "push", "-r", "stack", "--allow-new"]
+
+# =============================================================================
+# SYNC WORKFLOWS
+# =============================================================================
+
+# stack-sync - Fetch from remote and rebase your stack
+# What: Combines git fetch and stack-rebase into one command.
+# When: Use regularly to stay up-to-date with trunk.
+# Usage: jj stack-sync
+stack-sync = ["util", "exec", "--", "sh", "-c", "jj git fetch && jj rebase -s stack_base -d trunk"]
+
+# stack-start - Begin fresh work from trunk
+# What: Fetches latest changes and creates a new commit on trunk.
+# When: Use to start a new feature or bug fix from a clean slate.
+# Usage: jj stack-start
+stack-start = ["util", "exec", "--", "sh", "-c", "jj git fetch && jj new trunk"]
+
+# =============================================================================
+# STACK DIFF ALIASES
+# =============================================================================
+
+# stack-diff - Show diff from the beginning of the stack
+# What: Displays the full diff from where the stack branched off.
+# When: Use to see all changes in your entire stack.
+# Usage: jj stack-diff
+stack-diff = ["diff", "-f", "branch_off"]
+
+# stack-diff-summary - Show diff summary from the beginning of the stack
+# What: Shows a compact one-line-per-file summary for entire stack.
+# When: Use for a quick overview of all stack changes.
+# Usage: jj stack-diff-summary
+stack-diff-summary = ["diff-summary", "-f", "branch_off"]
+
+# stack-diff-files - List changed files from the beginning of the stack
+# What: Lists only filenames that changed in entire stack.
+# When: Use to see which files changed across your whole stack.
+# Usage: jj stack-diff-files
+stack-diff-files = ["diff-files", "-f", "branch_off"]
+

--- a/jj/conf.d/lazyjj-stack.toml
+++ b/jj/conf.d/lazyjj-stack.toml
@@ -121,23 +121,28 @@ stack-submit = ["git", "push", "-r", "stack", "--allow-new"]
 # Usage: jj stack-sync   (or the `sync` shortcut)
 stack-sync = ["util", "exec", "--", "bash", "-c", '''
 set -euo pipefail
+# All inner jj use --ignore-working-copy: this runs inside `jj util exec`, which
+# already holds the working copy. Letting inner commands check it out too races
+# the outer process -> "Concurrent checkout". Ignoring it here lets the outer
+# reconcile the working copy once, cleanly, when the script returns.
+J="jj --ignore-working-copy"
 # snapshot local bookmarks -> change_id BEFORE fetch (merged ones vanish on fetch)
-before=$(jj bookmark list -T 'name ++ "\t" ++ normal_target.change_id() ++ "\n"' --no-pager)
-jj git fetch
-after=$(jj bookmark list -T 'name ++ "\n"' --no-pager)
+before=$($J bookmark list -T 'name ++ "\t" ++ normal_target.change_id() ++ "\n"' --no-pager)
+$J git fetch
+after=$($J bookmark list -T 'name ++ "\n"' --no-pager)
 landed=0
 while IFS=$'\t' read -r name tip; do
   [ -n "$name" ] || continue
   printf '%s\n' "$after" | grep -qxF "$name" && continue   # still here -> not merged
   # vanished => squash-merged + branch-deleted upstream.
-  if [ -n "$(jj log -r "${tip}+::" -T '"x"' --no-graph --no-pager 2>/dev/null)" ]; then
-    jj rebase -s "roots(${tip}+::)" -d 'trunk()' >/dev/null   # children onto fresh trunk
+  if [ -n "$($J log -r "${tip}+::" -T '"x"' --no-graph --no-pager 2>/dev/null)" ]; then
+    $J rebase -s "roots(${tip}+::)" -d 'trunk()' >/dev/null   # children onto fresh trunk
   fi
-  jj abandon -r "::${tip} & ~::(trunk()) & mutable()" >/dev/null 2>&1 || true  # drop merged originals
+  $J abandon -r "::${tip} & ~::(trunk()) & mutable()" >/dev/null 2>&1 || true  # drop merged originals
   echo "  landed '$name' -- dropped merged duplicates, rebased children onto trunk"
   landed=1
 done < <(printf '%s\n' "$before")
-jj rebase -s stack_base -d 'trunk()' >/dev/null 2>&1 || true   # plain retrunk (no-op if already there)
+$J rebase -s stack_base -d 'trunk()' >/dev/null 2>&1 || true   # plain retrunk (no-op if already there)
 [ "$landed" -eq 1 ] && echo "  note: rewritten bookmarks need 'jj git push' (force-with-lease)"
 exit 0
 ''', ""]

--- a/jj/conf.d/lazyjj-stack.toml
+++ b/jj/conf.d/lazyjj-stack.toml
@@ -1,0 +1,1 @@
+/Users/brad.robinson/.config/jj/lazyjj/config/lazyjj-stack.toml

--- a/jj/conf.d/lazyjj-stack.toml
+++ b/jj/conf.d/lazyjj-stack.toml
@@ -71,7 +71,14 @@ restack = ["rebase", "-s", "stack_base", "-d", "trunk"]
 # What: Rebases all mutable stacks you've authored onto the latest trunk.
 # When: Use to update all your in-progress work with upstream changes.
 # Usage: jj restack-all
-restack-all = ["rebase", "-b", "roots(stacks)", "-d", "trunk()", "--skip-emptied"]
+restack-all = [
+  "rebase",
+  "-b",
+  "roots(stacks)",
+  "-d",
+  "trunk()",
+  "--skip-emptied",
+]
 
 # =============================================================================
 # BOOKMARK MANAGEMENT
@@ -95,7 +102,7 @@ create = ["bookmark", "create", "--to", "@-"]
 # What: Pushes all commits in your stack to remote, allowing new branches.
 # When: Use to push your stack for code review.
 # Usage: jj stack-submit
-stack-submit = ["git", "push", "-r", "stack", "--allow-new"]
+stack-submit = ["git", "push", "-r", "stack"]
 
 # =============================================================================
 # SYNC WORKFLOWS
@@ -119,7 +126,13 @@ stack-submit = ["git", "push", "-r", "stack", "--allow-new"]
 #       stale-reviews, will require re-approval — that's policy, not this command.
 # Validated in a throwaway repo against a real squash-merge + branch-delete.
 # Usage: jj stack-sync   (or the `sync` shortcut)
-stack-sync = ["util", "exec", "--", "bash", "-c", '''
+stack-sync = [
+  "util",
+  "exec",
+  "--",
+  "bash",
+  "-c",
+  '''
 set -euo pipefail
 # All inner jj use --ignore-working-copy: this runs inside `jj util exec`, which
 # already holds the working copy. Letting inner commands check it out too races
@@ -145,7 +158,9 @@ done < <(printf '%s\n' "$before")
 $J rebase -s stack_base -d 'trunk()' >/dev/null 2>&1 || true   # plain retrunk (no-op if already there)
 [ "$landed" -eq 1 ] && echo "  note: rewritten bookmarks need 'jj git push' (force-with-lease)"
 exit 0
-''', ""]
+''',
+  "",
+]
 
 # stack-start - Begin fresh work from trunk
 # What: Fetches latest changes and creates a new commit on trunk.
@@ -174,4 +189,3 @@ stack-diff-summary = ["diff-summary", "-f", "branch_off"]
 # When: Use to see which files changed across your whole stack.
 # Usage: jj stack-diff-files
 stack-diff-files = ["diff-files", "-f", "branch_off"]
-

--- a/jj/conf.d/lazyjj-stack.toml
+++ b/jj/conf.d/lazyjj-stack.toml
@@ -101,11 +101,46 @@ stack-submit = ["git", "push", "-r", "stack", "--allow-new"]
 # SYNC WORKFLOWS
 # =============================================================================
 
-# stack-sync - Fetch from remote and rebase your stack
-# What: Combines git fetch and stack-rebase into one command.
-# When: Use regularly to stay up-to-date with trunk.
-# Usage: jj stack-sync
-stack-sync = ["util", "exec", "--", "sh", "-c", "jj git fetch && jj rebase -s stack_base -d trunk"]
+# stack-sync - Fetch from remote and rebase your stack (squash-merge aware)
+# What: Fetch, then bring your stack up to date with trunk — the way the old
+#       `fetch && rebase -s stack_base -d trunk` did, PLUS handling for a parent
+#       PR that was squash-merged upstream. GitHub squashes a merged PR into one
+#       new commit on main and deletes its branch; on fetch, jj deletes the now-
+#       orphaned local bookmark. The old sync would then REPLAY your original
+#       (pre-squash) commits onto the new trunk that already contains them ->
+#       duplicate-commit conflicts (the "resolve everything as ours" ritual).
+# How: any local bookmark that vanished across the fetch was merged+deleted
+#      upstream. Rebase its surviving children onto trunk and ABANDON the merged
+#      originals (never replay them) -> zero conflicts. Then a normal retrunk for
+#      the plain "trunk just advanced" case. If nothing merged, identical to old.
+# When: Use regularly, and after a stacked parent PR merges.
+# Note: rebased children get new commit ids -> `jj git push` (force-with-lease).
+#       With squash-merge that push is unavoidable and, on repos with dismiss-
+#       stale-reviews, will require re-approval — that's policy, not this command.
+# Validated in a throwaway repo against a real squash-merge + branch-delete.
+# Usage: jj stack-sync   (or the `sync` shortcut)
+stack-sync = ["util", "exec", "--", "bash", "-c", '''
+set -euo pipefail
+# snapshot local bookmarks -> change_id BEFORE fetch (merged ones vanish on fetch)
+before=$(jj bookmark list -T 'name ++ "\t" ++ normal_target.change_id() ++ "\n"' --no-pager)
+jj git fetch
+after=$(jj bookmark list -T 'name ++ "\n"' --no-pager)
+landed=0
+while IFS=$'\t' read -r name tip; do
+  [ -n "$name" ] || continue
+  printf '%s\n' "$after" | grep -qxF "$name" && continue   # still here -> not merged
+  # vanished => squash-merged + branch-deleted upstream.
+  if [ -n "$(jj log -r "${tip}+::" -T '"x"' --no-graph --no-pager 2>/dev/null)" ]; then
+    jj rebase -s "roots(${tip}+::)" -d 'trunk()' >/dev/null   # children onto fresh trunk
+  fi
+  jj abandon -r "::${tip} & ~::(trunk()) & mutable()" >/dev/null 2>&1 || true  # drop merged originals
+  echo "  landed '$name' -- dropped merged duplicates, rebased children onto trunk"
+  landed=1
+done < <(printf '%s\n' "$before")
+jj rebase -s stack_base -d 'trunk()' >/dev/null 2>&1 || true   # plain retrunk (no-op if already there)
+[ "$landed" -eq 1 ] && echo "  note: rewritten bookmarks need 'jj git push' (force-with-lease)"
+exit 0
+''', ""]
 
 # stack-start - Begin fresh work from trunk
 # What: Fetches latest changes and creates a new commit on trunk.

--- a/jj/config.toml
+++ b/jj/config.toml
@@ -5,9 +5,12 @@ name = "Brad R"
 email = "31802085+bnrobinson93@users.noreply.github.com"
 
 [revsets]
-log = "latest(curbranch::@, 30) | @::nextbranch | @ | @- | children(@) | ancestors(@, 3) | my_other_bookmarks | my_other_leaves | (bases & my_bookmark_ranges) | bases"
+# Used by explicit `jj log` — broad cleanup-audit view: shows ALL my mutable leaf
+# tips (my_leaves), incl loose/unbookmarked, so I can spot + clean up strays.
+# Bare `jj` uses the tighter `clean_log` instead (see aliases.my_log).
+log = "latest(curbranch::@, 30) | @::nextbranch | @ | @- | children(@) | ancestors(@, 3) | my_other_bookmarks | my_leaves | (bases & my_bookmark_ranges) | bases"
 # 1. Current bookmark: full context near @
-# 2. Other bookmarks I own: only their tips + my leaves on them
+# 2. Other bookmarks I own: their tips + ALL my mutable leaf tips (incl loose)
 # 3. Keep bases that are relevant to my work, but *only* where my stuff lives
 
 [revset-aliases]
@@ -23,6 +26,15 @@ log = "latest(curbranch::@, 30) | @::nextbranch | @ | @- | children(@) | ancesto
 'my_other_bookmark_heads' = 'heads(my_other_bookmarks::)'
 'my_leaves' = 'heads(mine() & mutable())'
 'my_other_leaves' = 'my_leaves & my_other_bookmarks::'
+# clean_log: the tight daily view for bare `jj` (default-command). Same accordion
+# as revsets.log but folds far field to on-bookmark leaves only (my_other_leaves),
+# hiding loose strays. Use explicit `jj log` (revsets.log) to see + clean those.
+'clean_log' = 'latest(curbranch::@, 30) | @::nextbranch | @ | @- | children(@) | ancestors(@, 3) | my_other_bookmarks | my_other_leaves | (bases & my_bookmark_ranges) | bases'
+# stale: periodic-cleanup candidates. Old orphan work (no bookmark downstream,
+# not @ or its stack, 3wk+) + any of my empty mutable commits. Excludes @,
+# bookmarks, live stacks by construction. Preview: `jj log -r stale`.
+# Nuke (reversible via `jj undo`): `jj abandon -r stale`. Bookmark keepers first.
+'stale' = '(mine() & mutable() & ~@ & ~(@::) & ~(::bookmarks()) & committer_date(before:"3 weeks ago")) | (empty() & mine() & mutable() & ~@ & ~bookmarks())'
 'my_bookmark_ranges' = 'mybranches::'
 'recent()' = 'mine() & committer_date(after:"1 week ago") & ~empty()'
 'feature_branches()' = "bookmarks() ~ (trunk() | main)"
@@ -33,7 +45,7 @@ log = "latest(curbranch::@, 30) | @::nextbranch | @ | @- | children(@) | ancesto
 
 [aliases]
 base = ["log", "-r", "base(@)", "-T", "bookmarks", "--no-graph", "--limit", "1"]
-my_log = ["log", "-T", "my_default_log"]
+my_log = ["log", "-r", "clean_log", "-T", "my_default_log"]
 l = [
   "log",
   "-r",


### PR DESCRIPTION
Add lazyjj aliases, revsets, and integrations for GitHub, Claude, and stack-based workflows.

Modules:
- Core aliases (diff-summary, diff-files, log-short)
- GitHub stacked PRs (create, update, format)
- Claude workspace management and conflict resolution
- Stack revsets (trunk, branch_off, stack, stacks)
- Self-management cheat sheet
