### PR TITLE
feat(nvim): unify harper-ls lint rules with Obsidian plugin and add todo tag keymap

### DIFF
--- a/nvim/lua/config/options.lua
+++ b/nvim/lua/config/options.lua
@@ -11,6 +11,9 @@ vim.cmd([[let g:pencil#conceallevel = 1]])
 
 opt.spell = true
 vim.cmd([[set spelloptions+=camel]])
+-- Pin where `zg`/`zw` write additions (also harper-ls userDictPath) so it's
+-- deterministic instead of nvim auto-picking a runtimepath spell dir.
+opt.spellfile = vim.fn.stdpath("config") .. "/spell/en.utf-8.add"
 
 opt.guicursor = "n-v-c-sm:block-Cursor,i-ci-ve:ver35-Cursor,r-cr-o:hor30-Cursor"
 opt.mouse = "nv"

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -36,10 +36,28 @@ return {
         settings = {
           ["harper-ls"] = {
             userDictPath = vim.fn.stdpath("config") .. "/spell/en.utf-8.add",
-            linters = {
-              SpellCheck = false,
-              ExpandMemoryShorthands = false,
-            },
+            -- Inherit rule tuning from the Obsidian Harper plugin so both
+            -- editors share one tuning surface. Falls back to just the
+            -- nvim-only overrides when $ZETTELKASTEN / the file is missing.
+            linters = (function()
+              local out = {}
+              local vault = vim.env.ZETTELKASTEN
+              if vault and vault ~= "" then
+                local p = vault .. "/.obsidian/plugins/harper/data.json"
+                -- luanil drops JSON nulls (harper defaults) so only real
+                -- true/false toggles survive the copy.
+                local ok, data = pcall(function()
+                  return vim.json.decode(table.concat(vim.fn.readfile(p), "\n"), { luanil = { object = true } })
+                end)
+                if ok and type(data) == "table" and type(data.lintSettings) == "table" then
+                  out = vim.tbl_extend("force", out, data.lintSettings)
+                end
+              end
+              -- nvim-only overrides win
+              out.SpellCheck = false
+              out.ExpandMemoryShorthands = false
+              return out
+            end)(),
           },
         },
       },

--- a/nvim/lua/plugins/obsidian.lua
+++ b/nvim/lua/plugins/obsidian.lua
@@ -720,6 +720,13 @@ return {
         mode = "i",
         buffer = true,
       },
+      {
+        "<leader>xt",
+        "<cmd>Obsidian tags todo<cr>",
+        desc = "Obsidian #todo tags",
+        mode = { "n" },
+        buffer = true,
+      },
     },
   },
 }

--- a/nvim/spell/en.utf-8.add
+++ b/nvim/spell/en.utf-8.add
@@ -64,3 +64,4 @@ Christy
 
 ABAC
 s4
+SDK


### PR DESCRIPTION
- Pin spellfile to a deterministic path so `zg`/`zw` and harper-ls share one dictionary
- Load harper lint settings from the Obsidian Harper plugin's `data.json`, falling back to nvim-only overrides
- Add `<leader>xt` keymap to list Obsidian `#todo` tags
