### PR TITLE
chore: document engineering skill setup, include colima ssh config

### DIFF
--- a/ai/AGENTS.md
+++ b/ai/AGENTS.md
@@ -51,6 +51,15 @@ skills/<name>/SKILL.md (at root, e.g. ~/.dotfiles/ai/skills) for named or clearl
 
 Codex sandbox note: `hunk session` commands talk to a local daemon on 127.0.0.1, which the sandbox blocks. In Codex, request escalated permissions upfront for `hunk session` commands (with a one-line justification) instead of running sandboxed first, failing, and retrying.
 
+## Engineering skill configuration
+
+For skills requiring per-repo configuration:
+
+- Set `<repo>` from the `origin` remote's repository name, without `.git`; fall back to the workspace-root directory name when no remote exists
+- Read `~/Documents/Vault/2-Areas/Coding/<repo>/Agents/`
+- Save issue and spec drafts under the sibling `Issues/` directory
+- Follow `Issue Tracker.md`, `Triage Labels.md`, and `Domain Docs.md`; run `setup-matt-pocock-skills` with this vault layout when configuration is missing
+
 ## Caveman
 
 caveman.md (at root, e.g. ~/.claude or ~/.codex) for explicit caveman mode usage.

--- a/dot-ssh/config
+++ b/dot-ssh/config
@@ -1,3 +1,5 @@
+Include /Users/brad.robinson/.colima/ssh_config
+
 ## Managed by dotfiles (stow). Safe to edit.
 #
 # Connection strategy per machine. Commit signing is separate — git/jj invoke


### PR DESCRIPTION
## Context

Two housekeeping changes riding the matt-pocock branch: the repo's AI entry point now spells out how per-repo engineering skill config is resolved, and ssh picks up Colima's host config.

## The Case

The Matt Pocock skills (issue tracker, triage labels, domain docs) need per-repo configuration. Until now that wiring lived in my head, which is exactly where it shouldn't. AGENTS.md now records the rules: `<repo>` comes from the `origin` remote name, config reads from the vault's `Coding/<repo>/Agents/` dir, drafts go under the sibling `Issues/` dir, and `setup-matt-pocock-skills` covers the bootstrap case.

Separately, the ssh config starts by including `/Users/brad.robinson/.colima/ssh_config` so Colima's VM host entries resolve when Docker contexts point at it.

## Closing

Two small files, two fewer places to guess. Anything else on the branch still looks like a candidate for a real commit message — say the word and I'll split them.
