### PR TITLE
fix(jj): scope stack-sync bookmark scan to current stack

### DIFF
--- a/jj/conf.d/lazyjj-stack.toml
+++ b/jj/conf.d/lazyjj-stack.toml
@@ -126,7 +126,7 @@ stack-sync = [
 set -euo pipefail
 J=(jj --ignore-working-copy)
 old_trunk=$("${J[@]}" log -r 'trunk()' -T 'commit_id ++ "\n"' --no-graph --no-pager)
-before=$("${J[@]}" bookmark list --all-remotes -T 'if(remote == "origin", name ++ "\t" ++ normal_target.change_id() ++ "\n", "")' --no-pager)
+before=$("${J[@]}" bookmark list --revision 'branch_off+::@' --all-remotes -T 'if(remote == "origin", name ++ "\t" ++ normal_target.change_id() ++ "\n", "")' --no-pager)
 
 "${J[@]}" git fetch
 


### PR DESCRIPTION
## Context

`stack-sync` snapshots every origin bookmark (`jj bookmark list --all-remotes`) before and after fetch, then walks the list looking for squash-merged tips. On a repo with many stale branches that snapshot is big, and the follow-up `grep`/`jj log` loop pays for all of it.

The change narrows the `before` snapshot to the only bookmarks sync actually cares about: ones whose target sits in `branch_off+::@`, the stack's own revision range.

## The Case

- `before` was "list everything origin knows", `after` was "list everything origin knows". Only the intersection mattered
- `--revision 'branch_off+::@'` makes the scan proportional to stack size, not repo branch count
- Behavior unchanged for the bug it originally fixed (delete-parent detection): any bookmark touching the stack still lands in the snapshot

Perf-only, no semantic shift.

## Closing

`jj stack-sync` on repos with hundreds of origin branches should drop from scanning noise to a few revset rows. Worth timing before and after on your biggest repo?
