### PR TITLE
feat: ai tweaks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,8 @@ This is a dotfiles repository managing a complete Linux development environment 
 
 ```bash
 # Preferred: mise tasks work from anywhere
-mise run stow     # deploy all symlinks (config, ~/.local, zsh, ai, ssh)
-mise run skills   # install/update AI skills & plugins
+mise run stow     # deploy non-AI symlinks (config, ~/.local, zsh, ssh)
+mise run skills   # deploy AI config and install/update skills and plugins
 mise run update   # update everything via topgrade
 
 # Manual equivalents:

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ brew install k9s helm age agg
 Day-to-day, mise tasks cover the common operations from anywhere:
 
 ```sh
-mise run stow     # deploy all symlinks (config, ~/.local, zsh, ai, ssh)
-mise run skills   # install/update AI skills & plugins (update-skills.sh)
+mise run stow     # deploy non-AI symlinks (config, ~/.local, zsh, ssh)
+mise run skills   # deploy AI config and install/update skills and plugins
 mise run update   # update everything via topgrade
 ```
 
@@ -171,23 +171,9 @@ chsh -s $(which fish)
 tmux source-file ${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf
 bat cache --build
 
-# Shared AI instruction files (either shell)
-# Remove previously stowed AI links before restowing
-stow -D -t ~/.claude ai || true
-stow -D -t ~/.codex ai || true
-stow -D -t ~/.config/opencode ai || true
-
-# Back up conflicting Claude entrypoints before restowing
-mv ~/.claude/AGENTS.md ~/.claude/AGENTS.md.pre-dotfiles.$(date +%Y%m%d%H%M%S).bak 2>/dev/null || true
-mv ~/.claude/CLAUDE.md ~/.claude/CLAUDE.md.pre-dotfiles.$(date +%Y%m%d%H%M%S).bak 2>/dev/null || true
-
-stow -v2 -t ~/.claude ai
-stow -v2 -t ~/.codex ai
-stow -v2 -t ~/.config/opencode ai
-
-# Update agent skills/plugins
+# Deploy AI config and update skills/plugins
 update-skills.sh
-# Optional: TEACH_SKILL_SOURCE=owner/repo update-skills.sh
+# Optional: FIGMA_SKILL_SOURCE=owner/repo TEACH_SKILL_SOURCE=owner/repo update-skills.sh
 
 ### Default SSH key setup (no 1Password)
 

--- a/ai/AGENTS.md
+++ b/ai/AGENTS.md
@@ -1,65 +1,23 @@
 # AI Entry Point
 
-Shared instruction entry point for Claude, Codex, and OpenCode.
+Shared instructions for Claude, Codex, and OpenCode.
 
-## Communication Style
+## Communication
 
-- Terse like caveman. Technical substance exact. Only fluff die.
-- Drop: articles, filler (just/really/basically), pleasantries, hedging.
-- Fragments OK. Short synonyms.
-- Code unchanged.
-- Pattern: [thing] [action] [reason]. [next step].
-- ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift.
-- Code/commits/PRs: normal.
-- Off: "stop caveman" / "normal mode".
+- Terse like caveman; keep technical substance exact
+- Drop articles, filler, pleasantries, and hedging
+- Fragments and short synonyms are fine
+- Leave code, commits, and PR prose normal
+- Pattern: `[thing] [action] [reason]. [next step].`
+- Stay terse until the user says `stop caveman` or `normal mode`
 
-## Running Development Servers
+## Runtime
 
-Dev server already running with `pnpm` or `go`. Can provide output if needed.
+- Development servers usually already run with `pnpm` or `go`; ask for output when needed
 
-## Shared Memory
+## Version control
 
-For durable project/user memory, read: `~/.claude/projects/-Users-brad-robinson--dotfiles/memory/MEMORY.md`
-
-Note that "-Users-brad-robinson--dotfiles" is taken from `ls -1d ~/.dotfiles | sed 's/\./-/g; s/\//-/g'` so it may differ between machines
-
-Follow links from that MEMORY.md when relevant.
-
-When user asks to remember a decision, code nuance, workflow, or location:
-
-- Add/update a focused file in that `memory/` dir.
-- Add one bullet to `MEMORY.md` linking it.
-- Capture Why, Applies to, and Failure mode when useful.
-
-## VCS - Version Control
-
-I generally work in JJ VCS, as such, assume that you're in a JJ workspace by default. Before starting work that would mutate files, unless I already stated that it's git vs jj, detect whether in a JJ or git repo, so that you're grounded in reality. Refer to VCS.md (at root, e.g. ~/.claude or ~/.codex) for details.
-
-To detect the VCS, prefer evidence already in context (a `.jj` directory in a listing means JJ, even when `.git` also exists — colocated). Otherwise run `jj workspace root`; if it succeeds, JJ. If it fails, run `git rev-parse --show-toplevel`; if it succeeds, git; otherwise no VCS. Run these as two separate plain commands — never wrap them in subshells, `&&`/`||` chains, or redirects, because compound commands defeat command allowlists and force approval prompts.
-
-## Writing Voice
-
-Before writing or editing long-form prose, documentation, decision docs, READMEs, or publishable code comments, MUST read WritingVoice.md (at root, e.g. ~/.claude or ~/.codex). Applies when prose matters or user will share the artifact. Does not apply to caveman-mode chat, terse status updates, or routine code.
-
-## Code Quality
-
-When coding, consider CodeQuality.md (at root, e.g. ~/.claude or ~/.codex)
-
-## Skills
-
-skills/<name>/SKILL.md (at root, e.g. ~/.dotfiles/ai/skills) for named or clearly applicable local skills. Read the specific skill only when needed.
-
-Codex sandbox note: `hunk session` commands talk to a local daemon on 127.0.0.1, which the sandbox blocks. In Codex, request escalated permissions upfront for `hunk session` commands (with a one-line justification) instead of running sandboxed first, failing, and retrying.
-
-## Engineering skill configuration
-
-For skills requiring per-repo configuration:
-
-- Set `<repo>` from the `origin` remote's repository name, without `.git`; fall back to the workspace-root directory name when no remote exists
-- Read `~/Documents/Vault/2-Areas/Coding/<repo>/Agents/`
-- Save issue and spec drafts under the sibling `Issues/` directory
-- Follow `Issue Tracker.md`, `Triage Labels.md`, and `Domain Docs.md`; run `setup-matt-pocock-skills` with this vault layout when configuration is missing
-
-## Caveman
-
-caveman.md (at root, e.g. ~/.claude or ~/.codex) for explicit caveman mode usage.
+- Assume JJ by default; follow `VCS.md` from the active agent root
+- Before file mutations, use existing evidence or run `jj workspace root`
+- If JJ detection fails, run `git rev-parse --show-toplevel` separately
+- Never combine VCS detection commands; compound commands defeat allowlists

--- a/ai/dot-claude/hooks/caveman-statusline.sh
+++ b/ai/dot-claude/hooks/caveman-statusline.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# statusline for Claude Code
+# Renders caveman mode, repo, PR, branch, context, and worktree.
+
+input=$(cat)
+
+# caveman mode
+FLAG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.caveman-active"
+if [ ! -L "$FLAG" ] && [ -f "$FLAG" ]; then
+  MODE=$(head -c 64 "$FLAG" 2>/dev/null | tr -d '\n\r' | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9-')
+  case "$MODE" in
+    off|lite|full|ultra|wenyan-lite|wenyan|wenyan-full|wenyan-ultra|commit|review|compress)
+      if [ -z "$MODE" ] || [ "$MODE" = "full" ]; then
+        printf '\033[38;5;172m[CAVEMAN]\033[0m '
+      else
+        SUFFIX=$(printf '%s' "$MODE" | tr '[:lower:]' '[:upper:]')
+        printf '\033[38;5;172m[CAVEMAN:%s]\033[0m ' "$SUFFIX"
+      fi
+
+      # caveman savings suffix
+      if [ "${CAVEMAN_STATUSLINE_SAVINGS:-1}" != "0" ]; then
+        SAVINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.caveman-statusline-suffix"
+        if [ -f "$SAVINGS_FILE" ] && [ ! -L "$SAVINGS_FILE" ]; then
+          SAVINGS=$(head -c 64 "$SAVINGS_FILE" 2>/dev/null | tr -d '\000-\037')
+          [ -n "$SAVINGS" ] && printf '\033[38;5;172m%s\033[0m ' "$SAVINGS"
+        fi
+      fi
+      ;;
+  esac
+fi
+
+# repo owner/name
+repo=$(echo "$input" | jq -r '.workspace.repo | if . then .owner + "/" + .name else empty end')
+[ -n "$repo" ] && printf '\033[38;5;111m%s\033[0m ' "$repo"
+
+# worktree (jj workspace)
+wt=$(echo "$input" | jq -r '.worktree.name // empty')
+[ -n "$wt" ] && printf '\033[38;5;183m[wt:%s]\033[0m ' "$wt"
+
+# jj workspace / bookmark / desc, else git branch
+if type jj >/dev/null 2>&1 && jj --ignore-working-copy workspace root >/dev/null 2>&1; then
+  # ws<TAB>change-id<TAB>description
+  IFS=$'\t' read -r ws cid desc < <(jj --ignore-working-copy log -r @ --no-graph \
+    -T 'working_copies.map(|w| w.name()).join(",") ++ "\t" ++ change_id.shortest(8) ++ "\t" ++ description.first_line()' 2>/dev/null)
+  bm=$(jj --ignore-working-copy log -r 'closest_bookmark(@)' --no-graph \
+    -T 'bookmarks.map(|b| b.name()).join(" ")' 2>/dev/null | awk '{print $1}')
+
+  [ -n "$ws" ] && printf '\033[38;5;78m%s\033[0m' "$ws"
+  [ -n "$bm" ] && printf '\033[38;5;244m/\033[38;5;213m%s\033[0m' "$bm"
+  printf '\033[38;5;244m/\033[0m\033[38;5;255m%s\033[0m ' "${desc:-$cid}"
+elif type git >/dev/null 2>&1 && git rev-parse --show-toplevel >/dev/null 2>&1; then
+  branch=$(git -c advice.detachedHead=false symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)
+  [ -n "$branch" ] && printf '\033[38;5;214m%s\033[0m ' "$branch"
+fi
+
+# PR badge
+pr=$(echo "$input" | jq -r '.pr.number // empty')
+if [ -n "$pr" ]; then
+  state=$(echo "$input" | jq -r '.pr.review_state // "open"')
+  printf '\033[38;5;156mPR#%s(%s)\033[0m ' "$pr" "$state"
+fi
+
+# context used: "12.3k (34%)" — tokens yellow, parens gray
+ctx=$(echo "$input" | jq -r '
+  .context_window // empty
+  | (.total_input_tokens // empty) as $t
+  | (.used_percentage // (if .remaining_percentage then 100 - .remaining_percentage else empty end)) as $p
+  | if $t then (if $t >= 1000 then ((($t/100)|floor)/10|tostring) + "k" else ($t|tostring) end) else "" end
+    + " " + (if $p then (($p|floor)|tostring) else "" end)')
+tok=${ctx% *}
+pct=${ctx#* }
+[ -n "$tok" ] && printf '\033[38;5;220m%s\033[0m' "$tok"
+[ -n "$pct" ] && printf '\033[38;5;244m (%s%%)\033[0m' "$pct"

--- a/ai/dot-claude/hooks/caveman-statusline.sh
+++ b/ai/dot-claude/hooks/caveman-statusline.sh
@@ -4,6 +4,18 @@
 
 input=$(cat)
 
+# Catppuccin Mocha palette (truecolor, matches terminal theme)
+PEACH=$'\033[38;2;250;179;135m'
+BLUE=$'\033[38;2;137;180;250m'
+LAVENDER=$'\033[38;2;180;190;254m'
+GREEN=$'\033[38;2;166;227;161m'
+PINK=$'\033[38;2;245;194;231m'
+TEAL=$'\033[38;2;148;226;213m'
+YELLOW=$'\033[38;2;249;226;175m'
+TEXT=$'\033[38;2;205;214;244m'
+OVERLAY=$'\033[38;2;108;112;134m'
+OFF=$'\033[0m'
+
 # caveman mode
 FLAG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.caveman-active"
 if [ ! -L "$FLAG" ] && [ -f "$FLAG" ]; then
@@ -11,10 +23,10 @@ if [ ! -L "$FLAG" ] && [ -f "$FLAG" ]; then
   case "$MODE" in
     off|lite|full|ultra|wenyan-lite|wenyan|wenyan-full|wenyan-ultra|commit|review|compress)
       if [ -z "$MODE" ] || [ "$MODE" = "full" ]; then
-        printf '\033[38;5;172m[CAVEMAN]\033[0m '
+        printf '%s[CAVEMAN]%s ' "$PEACH" "$OFF"
       else
         SUFFIX=$(printf '%s' "$MODE" | tr '[:lower:]' '[:upper:]')
-        printf '\033[38;5;172m[CAVEMAN:%s]\033[0m ' "$SUFFIX"
+        printf '%s[CAVEMAN:%s]%s ' "$PEACH" "$SUFFIX" "$OFF"
       fi
 
       # caveman savings suffix
@@ -22,7 +34,7 @@ if [ ! -L "$FLAG" ] && [ -f "$FLAG" ]; then
         SAVINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.caveman-statusline-suffix"
         if [ -f "$SAVINGS_FILE" ] && [ ! -L "$SAVINGS_FILE" ]; then
           SAVINGS=$(head -c 64 "$SAVINGS_FILE" 2>/dev/null | tr -d '\000-\037')
-          [ -n "$SAVINGS" ] && printf '\033[38;5;172m%s\033[0m ' "$SAVINGS"
+          [ -n "$SAVINGS" ] && printf '%s%s%s ' "$PEACH" "$SAVINGS" "$OFF"
         fi
       fi
       ;;
@@ -31,36 +43,50 @@ fi
 
 # repo owner/name
 repo=$(echo "$input" | jq -r '.workspace.repo | if . then .owner + "/" + .name else empty end')
-[ -n "$repo" ] && printf '\033[38;5;111m%s\033[0m ' "$repo"
+[ -n "$repo" ] && printf '%s%s%s ' "$BLUE" "$repo" "$OFF"
 
 # worktree (jj workspace)
 wt=$(echo "$input" | jq -r '.worktree.name // empty')
-[ -n "$wt" ] && printf '\033[38;5;183m[wt:%s]\033[0m ' "$wt"
+[ -n "$wt" ] && printf '%s[wt:%s]%s ' "$LAVENDER" "$wt" "$OFF"
 
 # jj workspace / bookmark / desc, else git branch
 if type jj >/dev/null 2>&1 && jj --ignore-working-copy workspace root >/dev/null 2>&1; then
-  # ws<TAB>change-id<TAB>description
-  IFS=$'\t' read -r ws cid desc < <(jj --ignore-working-copy log -r @ --no-graph \
-    -T 'working_copies.map(|w| w.name()).join(",") ++ "\t" ++ change_id.shortest(8) ++ "\t" ++ description.first_line()' 2>/dev/null)
+  # ws<US>change-id<US>description — \x1f is non-whitespace, so empty fields survive `read`
+  IFS=$'\x1f' read -r ws cid desc < <(jj --ignore-working-copy log -r @ --no-graph \
+    -T 'working_copies.map(|w| w.name()).join(",") ++ "\x1f" ++ change_id.shortest(8) ++ "\x1f" ++ description.first_line()' 2>/dev/null)
   bm=$(jj --ignore-working-copy log -r 'closest_bookmark(@)' --no-graph \
     -T 'bookmarks.map(|b| b.name()).join(" ")' 2>/dev/null | awk '{print $1}')
 
-  [ -n "$ws" ] && printf '\033[38;5;78m%s\033[0m' "$ws"
-  [ -n "$bm" ] && printf '\033[38;5;244m/\033[38;5;213m%s\033[0m' "$bm"
-  printf '\033[38;5;244m/\033[0m\033[38;5;255m%s\033[0m ' "${desc:-$cid}"
+  # desc, else Claude's suggested session name, else change id
+  if [ -z "$desc" ]; then
+    desc=$(echo "$input" | jq -r '.session_name // empty' | tr -d '\000-\037')
+    [ ${#desc} -gt 40 ] && desc="${desc:0:39}…"
+  fi
+
+  # join present segments with a slash — no leading/dangling separators
+  sep=''
+  if [ -n "$ws" ]; then
+    printf '%s%s%s' "$GREEN" "$ws" "$OFF"
+    sep="$OVERLAY/$OFF"
+  fi
+  if [ -n "$bm" ]; then
+    printf '%s%s%s%s' "$sep" "$PINK" "$bm" "$OFF"
+    sep="$OVERLAY/$OFF"
+  fi
+  printf '%s%s%s%s ' "$sep" "$TEXT" "${desc:-$cid}" "$OFF"
 elif type git >/dev/null 2>&1 && git rev-parse --show-toplevel >/dev/null 2>&1; then
   branch=$(git -c advice.detachedHead=false symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)
-  [ -n "$branch" ] && printf '\033[38;5;214m%s\033[0m ' "$branch"
+  [ -n "$branch" ] && printf '%s%s%s ' "$PEACH" "$branch" "$OFF"
 fi
 
 # PR badge
 pr=$(echo "$input" | jq -r '.pr.number // empty')
 if [ -n "$pr" ]; then
   state=$(echo "$input" | jq -r '.pr.review_state // "open"')
-  printf '\033[38;5;156mPR#%s(%s)\033[0m ' "$pr" "$state"
+  printf '%sPR#%s(%s)%s ' "$TEAL" "$pr" "$state" "$OFF"
 fi
 
-# context used: "12.3k (34%)" — tokens yellow, parens gray
+# context used: "12.3k (34%)" — tokens yellow, parens dim
 ctx=$(echo "$input" | jq -r '
   .context_window // empty
   | (.total_input_tokens // empty) as $t
@@ -69,5 +95,5 @@ ctx=$(echo "$input" | jq -r '
     + " " + (if $p then (($p|floor)|tostring) else "" end)')
 tok=${ctx% *}
 pct=${ctx#* }
-[ -n "$tok" ] && printf '\033[38;5;220m%s\033[0m' "$tok"
-[ -n "$pct" ] && printf '\033[38;5;244m (%s%%)\033[0m' "$pct"
+[ -n "$tok" ] && printf '%s%s%s' "$YELLOW" "$tok" "$OFF"
+[ -n "$pct" ] && printf '%s (%s%%)%s' "$OVERLAY" "$pct" "$OFF"

--- a/ai/dot-config/ponytail/config.json
+++ b/ai/dot-config/ponytail/config.json
@@ -1,0 +1,3 @@
+{
+  "defaultMode": "off"
+}

--- a/ai/skills/load-engineering-context/SKILL.md
+++ b/ai/skills/load-engineering-context/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: load-engineering-context
+description: Load repository-specific issue tracking, triage labels, domain docs, and draft locations for engineering workflows. Use before QA, issue filing, refactor planning, domain modeling, spec drafting, or any skill requiring per-repository configuration.
+---
+
+# Load engineering context
+
+1. Derive `<repo>` from the `origin` remote repository name without `.git`; fall back to the workspace-root directory name
+2. Read `~/Documents/Vault/2-Areas/Coding/<repo>/Agents/`
+3. Follow `Issue Tracker.md`, `Triage Labels.md`, and `Domain Docs.md`
+4. Save issue and spec drafts under sibling `Issues/`
+5. Run `setup-matt-pocock-skills` with this vault layout when configuration is missing
+
+Do not invent tracker fields, labels, or domain terms when repository configuration exists.

--- a/ai/skills/load-engineering-context/agents/openai.yaml
+++ b/ai/skills/load-engineering-context/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Load Engineering Context"
+  short_description: "Load repository issue and domain conventions"
+  default_prompt: "Use $load-engineering-context to load this repository’s issue and domain configuration."

--- a/ai/skills/remember-context/SKILL.md
+++ b/ai/skills/remember-context/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: remember-context
+description: Store durable project or user memory for future agent sessions. Use when the user asks to remember, save, or preserve a decision, code nuance, workflow, preference, or important location.
+---
+
+# Remember context
+
+1. Read `~/.claude/projects/-Users-brad-robinson--dotfiles/memory/MEMORY.md`
+2. Follow existing links relevant to the subject
+3. Add or update one focused file in the same `memory/` directory
+4. Add one concise bullet to `MEMORY.md` linking that file
+5. Capture `Why`, `Applies to`, and `Failure mode` when useful
+
+The project slug derives from `ls -1d ~/.dotfiles | sed 's/\./-/g; s/\//-/g'`; resolve the equivalent path when it differs between machines.
+
+Store durable facts only. Exclude secrets, transient task state, and information already canonical in repository files.

--- a/ai/skills/remember-context/agents/openai.yaml
+++ b/ai/skills/remember-context/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Remember Context"
+  short_description: "Store durable project and user memory"
+  default_prompt: "Use $remember-context to preserve this decision for future sessions."

--- a/install.sh
+++ b/install.sh
@@ -42,45 +42,19 @@ brew install lazygit asciinema agg jj mise gh jq topgrade dlvhdr/formulae/diffna
 echo "Installing neovim via brew (you will likely want to change this)"
 brew install neovim
 
-mkdir -p ~/.local ~/.config ~/.ssh ~/.config/hypr ~/.claude ~/.codex ~/.config/opencode
+mkdir -p ~/.local ~/.config ~/.ssh ~/.config/hypr
 pushd "$(dirname -- "$0")" || exit
-
-backup_conflicting_ai_entrypoint() {
-  local target="$1"
-  if [[ ! -e "$target" && ! -L "$target" ]]; then
-    return 0
-  fi
-
-  local backup_target="${target}.pre-dotfiles.$(date +%Y%m%d%H%M%S).bak"
-  echo "Backing up existing $(basename "$target") to $backup_target"
-  mv "$target" "$backup_target"
-}
 
 echo Clearing install files to avoid stow conflicts...
 for path in fish ghostty git kitty nvim mise tmux starship.toml; do
   rm -rf "$HOME/.config/$path"
 done
 
-echo "Removing previously stowed AI instruction links..."
-stow -D -t ~/.claude ai 2>/dev/null || true
-stow -D -t ~/.codex ai 2>/dev/null || true
-stow -D -t ~/.config/opencode ai 2>/dev/null || true
-stow -D -d ai -t ~/.codex dot-codex 2>/dev/null || true
-
-echo "Backing up conflicting Claude entrypoints before restowing..."
-backup_conflicting_ai_entrypoint "$HOME/.claude/AGENTS.md"
-backup_conflicting_ai_entrypoint "$HOME/.claude/CLAUDE.md"
-
-ai_stow_args=(--ignore=dot-codex --ignore='^skills/(teach|hunk-review)$')
-
 echo Populating config and local scripts...
 stow -v2 .
 stow -v2 starship
 stow -v2 -t ~/.local -S dot-local --dotfiles
 stow -v2 -t ~ -S zsh --dotfiles
-stow -v2 "${ai_stow_args[@]}" -t ~/.claude ai
-stow -v2 "${ai_stow_args[@]}" -t ~/.codex ai
-stow -v2 "${ai_stow_args[@]}" -t ~/.config/opencode ai
 stow -v2 -t ~/.ssh -S dot-ssh --dotfiles
 
 cp -pR hypr/* ~/.config/hypr/
@@ -112,7 +86,7 @@ chsh -s "$(which fish)"
 echo Getting the nice to haves...
 brew install dust eza fd uutils-coreutils danielgatis/imgcat/imgcat hunk
 
-echo "Installing AI skills and plugins..."
+echo "Deploying AI config and updating skills/plugins..."
 "$PWD/update-skills.sh" || true
 
 echo Installing Herdr...

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -18,21 +18,18 @@ usage = "latest"
 # install.sh should shrink into these over time.
 
 [tasks.stow]
-description = "Deploy dotfiles symlinks (config, local bin, home, ai, ssh)"
+description = "Deploy non-AI dotfiles symlinks (config, local bin, home, ssh)"
 dir = "~/.dotfiles"
 run = [
   "stow -v2 .",
   "stow -v2 starship",
   "stow -v2 -t ~/.local -S dot-local --dotfiles",
   "stow -v2 -t ~ -S zsh --dotfiles",
-  "stow -v2 --ignore=dot-codex --ignore='^skills/(teach|hunk-review)$' -t ~/.claude ai",
-  "stow -v2 --ignore=dot-codex --ignore='^skills/(teach|hunk-review)$' -t ~/.codex ai",
-  "stow -v2 --ignore=dot-codex --ignore='^skills/(teach|hunk-review)$' -t ~/.config/opencode ai",
   "stow -v2 -t ~/.ssh -S dot-ssh --dotfiles",
 ]
 
 [tasks.skills]
-description = "Install/update AI skills and plugins (ponytail, hunk, teach, fabric)"
+description = "Deploy AI config and install/update skills and plugins"
 dir = "~/.dotfiles"
 run = "./update-skills.sh"
 

--- a/update-skills.sh
+++ b/update-skills.sh
@@ -2,6 +2,7 @@
 set -u
 
 failures=0
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 have() {
   command -v "$1" >/dev/null 2>&1
@@ -24,6 +25,48 @@ try() {
 
 try_quiet() {
   "$@" >/dev/null 2>&1
+}
+
+backup_conflicting_path() {
+  local target="$1"
+  local source="${2:-}"
+  if [[ ! -e "$target" && ! -L "$target" ]] || [[ -L "$target" ]]; then
+    return 0
+  fi
+
+  if [[ -n "$source" ]] && cmp -s "$target" "$source"; then
+    rm -- "$target"
+    return 0
+  fi
+
+  local backup_target="${target}.pre-dotfiles.$(date +%Y%m%d%H%M%S).bak"
+  printf 'Backing up existing %s to %s\n' "$(basename "$target")" "$backup_target"
+  mv "$target" "$backup_target"
+}
+
+deploy_local_ai() {
+  local shared_stow_args=(
+    --ignore=dot-codex
+    --ignore=dot-claude
+    --ignore=dot-config
+    --ignore='^skills/(teach|hunk-review)$'
+  )
+
+  try mkdir -p "$HOME/.claude" "$HOME/.codex" "$HOME/.config/opencode" "$HOME/.config"
+  backup_conflicting_path "$HOME/.claude/AGENTS.md"
+  backup_conflicting_path "$HOME/.claude/CLAUDE.md"
+  backup_conflicting_path \
+    "$HOME/.config/ponytail/config.json" \
+    "$script_dir/ai/dot-config/ponytail/config.json"
+
+  # Remove legacy Codex stow links; Codex and Herdr own these mutable files now.
+  try_quiet stow -D -d "$script_dir/ai" -t "$HOME/.codex" dot-codex || true
+
+  try stow -S -d "$script_dir" "${shared_stow_args[@]}" -t "$HOME/.claude" ai || true
+  try stow -S -d "$script_dir" "${shared_stow_args[@]}" -t "$HOME/.codex" ai || true
+  try stow -S -d "$script_dir" "${shared_stow_args[@]}" -t "$HOME/.config/opencode" ai || true
+  try stow -S -d "$script_dir/ai" -t "$HOME/.claude" dot-claude || true
+  try stow -S -d "$script_dir/ai" -t "$HOME/.config" dot-config || true
 }
 
 install_ponytail() {
@@ -65,6 +108,17 @@ install_hunk() {
   fi
 }
 
+install_figma() {
+  local source="${FIGMA_SKILL_SOURCE:-openai/skills}"
+
+  if have npx; then
+    try npx -y skills add "$source" --skill figma -g -a codex -y || true
+  else
+    failures=$((failures + 1))
+    printf 'warn: npx not found; cannot install figma skill from %s\n' "$source" >&2
+  fi
+}
+
 install_teach() {
   local source="${TEACH_SKILL_SOURCE:-mattpocock/skills}"
 
@@ -85,8 +139,10 @@ install_fabric() {
   printf 'note: run `fabric --setup` once to configure providers\n'
 }
 
+deploy_local_ai
 install_ponytail
 install_hunk
+install_figma
 install_teach
 install_fabric
 


### PR DESCRIPTION
Reorganize AI configuration deployment and simplify instruction entrypoints.

### What changed

**Simplified AI deployment:** Moved AI config stowing from `install.sh` into `update-skills.sh`. Now `mise run skills` handles all AI setup—entrypoint files, local hooks, configs, and skill installation.

**Cleaner instruction files:** Condensed `ai/AGENTS.md` from 65 to 23 lines. Kept the essentials (communication style, runtime, VCS detection, writing guidance); moved skill and engineering-context details into individual `load-engineering-context` and `remember-context` skill files where they belong.

**New hooks and configs:** Added Claude Code statusline hook (`caveman-statusline.sh`) for Caveman mode indication, token usage, and repo/branch context. Added `ponytail/config.json` to set default mode off.

**Skill scaffolding:** Created `load-engineering-context` and `remember-context` as reusable skills with OpenAI agent manifests, making per-repo configuration more discoverable.

**Updated task descriptions:** `mise run stow` now explicitly deploys non-AI symlinks (config, ~/.local, zsh, ssh). `mise run skills` covers AI config deployment plus skill installation. Reflected in README and CLAUDE.md.

### Why

Entrypoint files were spread across three locations with conflicting backup logic in install.sh. Moving everything into `update-skills.sh` centralizes the flow: back up conflicts, stow instructions/hooks/configs, then install external skills. Skill files document their own setup rules rather than living buried in shared AGENTS.md. Statusline hook brings Caveman mode state into view.
