### PR TITLE
fix(jj): pin stack-sync before-snapshot to commit ids

### DIFF
--- a/jj/conf.d/lazyjj-stack.toml
+++ b/jj/conf.d/lazyjj-stack.toml
@@ -126,7 +126,10 @@ stack-sync = [
 set -euo pipefail
 J=(jj --ignore-working-copy)
 old_trunk=$("${J[@]}" log -r 'trunk()' -T 'commit_id ++ "\n"' --no-graph --no-pager)
-before=$("${J[@]}" bookmark list --revision 'branch_off+::@' --all-remotes -T 'if(remote == "origin", name ++ "\t" ++ normal_target.change_id() ++ "\n", "")' --no-pager)
+# commit_id, not change_id: this is a pre-fetch snapshot, and the fetch below can
+# re-point a change (or make it divergent, which errors out and silently skips the
+# bookmark). Commit ids stay resolvable even once the commit is hidden.
+before=$("${J[@]}" bookmark list --revision 'branch_off+::@' --all-remotes -T 'if(remote == "origin", name ++ "\t" ++ normal_target.commit_id() ++ "\n", "")' --no-pager)
 
 "${J[@]}" git fetch
 


### PR DESCRIPTION
`stack-sync` captured each tracked bookmark's pre-fetch tip as a change id. The fetch that runs immediately after can re-point that change to the newly imported remote commit, or leave it divergent — and a divergent change id makes `jj log -r "\${tip}::@"` error out. Because that guard is written as:

```bash
[ -n "$("${J[@]}" log -r "\${tip}::@" -T '"x"' --no-graph --no-pager 2>/dev/null)" ] || continue
```

the error goes to `/dev/null`, stdout is empty, and the empty result reads as "not an ancestor of @". The bookmark is skipped without a word, so the squash-merged commits underneath the stack survive the sync and have to be cleaned up by hand.

This repo hits that case regularly: the GitHub Stacks beta rebases dependent PR branches server-side when a stack member merges, which is exactly what produces divergent change ids locally.

Commit ids can't be re-pointed and can't be ambiguous, and they stay resolvable after the commit is hidden — which is precisely what a *before* snapshot wants. Every other id in the script is already a commit id; this was the only `change_id()`.

The `--revision 'branch_off+::@'` scoping from #253 is unchanged, so the large-repo performance win is preserved.

Supersedes #246, which attempted a broader rewrite of the same detection logic.

## Verification
- TOML parses (`tomllib`, 15 aliases intact)
- `bash -n` clean on the extracted `stack-sync` body