### PR TITLE
chore: update AI skills and auto-add statusline

### DIFF
--- a/ai/dot-codex/skills/load-engineering-context
+++ b/ai/dot-codex/skills/load-engineering-context
@@ -1,0 +1,1 @@
+../../../ai/skills/load-engineering-context

--- a/ai/dot-codex/skills/remember-context
+++ b/ai/dot-codex/skills/remember-context
@@ -1,0 +1,1 @@
+../../../ai/skills/remember-context

--- a/ai/dot-codex/skills/tuicr-reivew
+++ b/ai/dot-codex/skills/tuicr-reivew
@@ -1,0 +1,1 @@
+../../../ai/skills/tuicr-reivew

--- a/jj/conf.d/lazyjj-stack.toml
+++ b/jj/conf.d/lazyjj-stack.toml
@@ -126,7 +126,10 @@ stack-sync = [
 set -euo pipefail
 J=(jj --ignore-working-copy)
 old_trunk=$("${J[@]}" log -r 'trunk()' -T 'commit_id ++ "\n"' --no-graph --no-pager)
-before=$("${J[@]}" bookmark list --revision 'branch_off+::@' --all-remotes -T 'if(remote == "origin", name ++ "\t" ++ normal_target.change_id() ++ "\n", "")' --no-pager)
+# commit_id, not change_id: this is a pre-fetch snapshot, and the fetch below can
+# re-point a change (or make it divergent, which errors out and silently skips the
+# bookmark). Commit ids stay resolvable even once the commit is hidden.
+before=$("${J[@]}" bookmark list --revision 'branch_off+::@' --all-remotes -T 'if(remote == "origin", name ++ "\t" ++ normal_target.commit_id() ++ "\n", "")' --no-pager)
 
 "${J[@]}" git fetch
 

--- a/update-skills.sh
+++ b/update-skills.sh
@@ -69,6 +69,41 @@ deploy_local_ai() {
   try stow -S -d "$script_dir/ai" -t "$HOME/.config" dot-config || true
 }
 
+# settings.json is mutable/plugin-managed (not stowed). Merge in the statusLine
+# key idempotently so it survives across machines without clobbering plugin edits.
+merge_claude_settings() {
+  local settings="$HOME/.claude/settings.json"
+  local statusline_cmd="bash '$HOME/.claude/hooks/caveman-statusline.sh'"
+
+  if ! have jq; then
+    failures=$((failures + 1))
+    printf 'warn: jq not found; skipping settings.json statusLine merge\n' >&2
+    return 1
+  fi
+
+  [[ -f "$settings" ]] || printf '{}\n' >"$settings"
+
+  local desired
+  desired=$(jq -n --arg cmd "$statusline_cmd" '{type: "command", command: $cmd}')
+
+  if [[ "$(jq -c '.statusLine // empty' "$settings" 2>/dev/null)" == "$(jq -c '.' <<<"$desired")" ]]; then
+    step "settings.json statusLine already current"
+    return 0
+  fi
+
+  step "merge statusLine into settings.json"
+  local tmp
+  tmp=$(mktemp)
+  if jq --argjson sl "$desired" '.statusLine = $sl' "$settings" >"$tmp"; then
+    mv "$tmp" "$settings"
+  else
+    rm -f "$tmp"
+    failures=$((failures + 1))
+    printf 'warn: failed to merge statusLine into settings.json\n' >&2
+    return 1
+  fi
+}
+
 install_ponytail() {
   local marketplace="${PONYTAIL_MARKETPLACE:-DietrichGebert/ponytail}"
 
@@ -140,6 +175,7 @@ install_fabric() {
 }
 
 deploy_local_ai
+merge_claude_settings
 install_ponytail
 install_hunk
 install_figma


### PR DESCRIPTION
## Context

Two housekeeping fixes, one branch.

Three Codex skills were missing their symlinks under `ai/dot-codex/skills/`, so `update-skills.sh` deployed them but Codex could not resolve them. They now point back to the canonical copies in `ai/skills/`.

`update-skills.sh` also gains `merge_claude_settings()`. The statusLine in `~/.claude/settings.json` is plugin-managed and lives outside stow, so it drifted between machines. The new step merges the `statusLine` key in idempotently via `jq`:

- no-op when already current
- creates `settings.json` when missing
- backs out cleanly (with a warn) when `jq` is absent or the merge fails
- temp-file write so a bad merge never truncates the live file

## The Case

The statusline script, `caveman-statusline.sh`, was already wired into the repo, but nothing ensured the hook pointed at it on a fresh machine. Relying on manual setup means the statusline silently vanishes until someone notices. A few lines in the deploy script beats a broken statusline discovered mid-demo.

Kept it a merge, not a stow target: settings.json changes under us (plugin edits), so overwriting it would clobber work, and symlinking fights the plugin's own writes.

## Closing

No statusline when `jq` is missing, but that's a loud warn, not a silent gap. If the merge ever needs to handle more than `statusLine`, the `jq` block extends rather than rewrites.

Any machine besides the ones already stowed that should be on the statusline?
