### PR TITLE
feat: remove blur from hyprlock background

### DIFF
--- a/hypr/hyprlock.conf
+++ b/hypr/hyprlock.conf
@@ -22,7 +22,6 @@ background {
     monitor =
     color = $color
     path = ~/.config/omarchy/current/background
-    blur_passes = 3
 }
 
 input-field {


### PR DESCRIPTION
## Context

Lock screen background renders blurry, obscuring the wallpaper. Locking should show the wallpaper as-is.

## Changes

- Drop `blur_passes = 3` from `hypr/hyprlock.conf` background block, wallpaper now renders sharp

## Notes

Ponytail: blur was the only non-default aesthetic on this block. If blur is wanted back, it's a one-line revert.
