### PR TITLE
feat: add Fish port helpers

### DIFF
--- a/fish/functions/findport.fish
+++ b/fish/functions/findport.fish
@@ -1,0 +1,3 @@
+function findport --argument-names port --description "Show processes listening on a port"
+    lsof -nP -iTCP:$port -sTCP:LISTEN
+end

--- a/fish/functions/killport.fish
+++ b/fish/functions/killport.fish
@@ -1,0 +1,6 @@
+function killport --argument-names port --description "Kill processes listening on a port"
+    set -l pids (lsof -tiTCP:$port -sTCP:LISTEN)
+    if set -q pids[1]
+        kill $pids
+    end
+end


### PR DESCRIPTION
## Context

Two tiny helpers for the port-kill dance, which previously meant typing `lsof` incantations twice per session

## Changes

- `findport` shows what's listening on a port (`lsof -nP -iTCP:$port -sTCP:LISTEN`)
- `killport` resolves the same list and kills it, no-op when nothing's there

Both are argument-named `port`, lazily loaded like every other function in `fish/functions/`, and they're plain `lsof` wrappers, so no state, no flags, nothing to drift

What port do you end up fighting most? That's the one this deserves a companion for, something like a `reuse` that frees and serves in one step
