### PR TITLE
feat(herdr): consolidate plugin setup and refine workspace sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ zed/conversations/
 zed/prompts/
 hunk/state.json
 jj/tests
+herdr/session.json
+herdr/release-notes.json
+herdr/session-history.json

--- a/dot-local/bin/jj-backfill-workspace-paths
+++ b/dot-local/bin/jj-backfill-workspace-paths
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+apply=false
+scan_root="$HOME/Documents/code"
+root_set=false
+
+usage() {
+  cat <<'EOF'
+Usage: jj-backfill-workspace-paths [--apply] [ROOT]
+
+Find pre-JJ-0.38 repositories whose default workspace has no recorded path.
+Runs as a dry-run unless --apply is provided. ROOT defaults to ~/Documents/code.
+Dry-run does not edit workspace paths; JJ may still perform normal repo migrations.
+
+Each repair backs up the workspace index beside the original, appends the
+default workspace path, and restores the backup if JJ cannot verify the result.
+EOF
+}
+
+while (($# > 0)); do
+  case "$1" in
+  --apply)
+    apply=true
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  -* )
+    printf 'Unknown option: %s\n' "$1" >&2
+    usage >&2
+    exit 2
+    ;;
+  *)
+    if [[ "$root_set" == true ]]; then
+      printf 'Only one scan root is supported.\n' >&2
+      exit 2
+    fi
+    scan_root=${1/#\~/$HOME}
+    root_set=true
+    ;;
+  esac
+  shift
+done
+
+if ! command -v jj >/dev/null 2>&1; then
+  printf 'jj is required.\n' >&2
+  exit 1
+fi
+
+if [[ ! -d "$scan_root" ]]; then
+  printf 'Not a directory: %s\n' "$scan_root" >&2
+  exit 1
+fi
+
+scan_root=$(cd "$scan_root" && pwd -P)
+run_id="$(date -u +%Y%m%dT%H%M%SZ).$$"
+error_file=$(mktemp "${TMPDIR:-/tmp}/jj-workspace-paths.XXXXXX")
+repair_temp=
+
+cleanup() {
+  rm -f "$error_file"
+  if [[ -n "$repair_temp" ]]; then
+    rm -f "$repair_temp"
+  fi
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+scanned=0
+repairable=0
+repaired=0
+skipped=0
+errors=0
+
+repair_repo() {
+  local jj_dir=$1
+  local repo_root=${jj_dir%/.jj}
+  local store_dir="$jj_dir/repo/workspace_store"
+  local index="$store_dir/index"
+  local current_name root_output root_error backup resolved_root
+  local store_missing=false
+
+  repo_root=$(cd "$repo_root" && pwd -P)
+  scanned=$((scanned + 1))
+
+  : >"$error_file"
+  if ! current_name=$(
+    jj --ignore-working-copy -R "$repo_root" workspace list \
+      --template 'if(target.current_working_copy(), name ++ "\n")' \
+      --color=never 2>"$error_file"
+  ); then
+    printf '[error] %s: %s\n' "$repo_root" "$(<"$error_file")" >&2
+    errors=$((errors + 1))
+    return
+  fi
+
+  if [[ "$current_name" != default ]]; then
+    printf '[skip] %s: primary workspace is %s, not default\n' "$repo_root" "$current_name"
+    skipped=$((skipped + 1))
+    return
+  fi
+
+  if [[ ! -d "$store_dir" ]]; then
+    store_missing=true
+    root_error='Workspace has no recorded path: default'
+  else
+    : >"$error_file"
+    if root_output=$(
+      jj --ignore-working-copy -R "$repo_root" workspace root --name default \
+        2>"$error_file"
+    ); then
+      printf '[ok] %s: %s\n' "$repo_root" "$root_output"
+      return
+    fi
+    root_error=$(<"$error_file")
+  fi
+
+  if [[ "$root_error" != *'Workspace has no recorded path: default'* ]]; then
+    printf '[skip] %s: %s\n' "$repo_root" "$root_error" >&2
+    skipped=$((skipped + 1))
+    return
+  fi
+
+  if [[ "$store_missing" != true && ! -f "$index" ]]; then
+    printf '[error] %s: workspace index is not a regular file\n' "$repo_root" >&2
+    errors=$((errors + 1))
+    return
+  fi
+
+  if [[ -e "$store_dir/index.lock" ]]; then
+    printf '[skip] %s: workspace index is locked\n' "$repo_root" >&2
+    skipped=$((skipped + 1))
+    return
+  fi
+
+  repairable=$((repairable + 1))
+  if [[ "$apply" != true ]]; then
+    printf '[would repair] %s\n' "$repo_root"
+    return
+  fi
+
+  if [[ "$store_missing" == true ]]; then
+    : >"$error_file"
+    if root_output=$(
+      jj --ignore-working-copy -R "$repo_root" workspace root --name default \
+        2>"$error_file"
+    ); then
+      printf '[ok] %s: %s\n' "$repo_root" "$root_output"
+      repairable=$((repairable - 1))
+      return
+    fi
+    root_error=$(<"$error_file")
+    if [[ "$root_error" != *'Workspace has no recorded path: default'* ]]; then
+      printf '[error] %s: %s\n' "$repo_root" "$root_error" >&2
+      errors=$((errors + 1))
+      return
+    fi
+  fi
+
+  if [[ ! -f "$index" ]]; then
+    printf '[error] %s: JJ did not initialize the workspace index\n' "$repo_root" >&2
+    errors=$((errors + 1))
+    return
+  fi
+
+  backup="$index.backup.$run_id"
+  cp -p "$index" "$backup"
+
+  repair_temp=$(mktemp "$store_dir/index.repair.XXXXXX")
+  chmod 600 "$repair_temp"
+  cp "$index" "$repair_temp"
+  printf '\x0a\x10\x0a\x07default\x12\x05../..' >>"$repair_temp"
+  mv "$repair_temp" "$index"
+  repair_temp=
+
+  : >"$error_file"
+  if root_output=$(
+    jj --ignore-working-copy -R "$repo_root" workspace root --name default \
+      2>"$error_file"
+  ); then
+    resolved_root=$(cd "$root_output" && pwd -P)
+    if [[ "$resolved_root" == "$repo_root" ]]; then
+      printf '[repaired] %s (backup: %s)\n' "$repo_root" "$backup"
+      repaired=$((repaired + 1))
+      return
+    fi
+  fi
+
+  cp -p "$backup" "$index"
+  printf '[error] %s: verification failed; backup restored\n' "$repo_root" >&2
+  errors=$((errors + 1))
+}
+
+while IFS= read -r -d '' jj_dir; do
+  [[ -d "$jj_dir/repo" ]] || continue
+  repair_repo "$jj_dir"
+done < <(find "$scan_root" -maxdepth 4 -type d -name .jj -prune -print0)
+
+printf '\nscanned=%d repairable=%d repaired=%d skipped=%d errors=%d\n' \
+  "$scanned" "$repairable" "$repaired" "$skipped" "$errors"
+
+if ((errors > 0)); then
+  exit 1
+fi

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -15,6 +15,23 @@ pane_gaps = true
 show_agent_labels_on_pane_borders = true
 prompt_new_tab_name = false
 
+[ui.sidebar.spaces]
+row_gap = 1
+rows = [
+  [
+    "state_icon",
+    "workspace",
+  ],
+  [
+    "branch",
+    "git_status",
+  ],
+  [
+    "$jj_bookmark",
+    "$jj_status",
+  ],
+]
+
 [keys]
 split_vertical = "prefix+|"
 split_horizontal = "prefix+-"
@@ -53,22 +70,29 @@ description = "jump to Obsidian vault"
 type = "shell"
 command = "herdr-workspace-at ~/Documents/Vault"
 
-# herdr plugin install NathanFlurry/herdr-plugin-jj-workspace
+# herdr plugin install EzraCerpac/jj-waltz/plugins/herdr
 [[keys.command]]
 key = "prefix+a"
 type = "plugin_action"
-command = "nathanflurry.jj-workspace.new"
-description = "new jj workspace"
+command = "ezracerpac.jj-waltz.new"
+description = "new jw workspace"
 [[keys.command]]
 key = "prefix+shift+a"
 type = "plugin_action"
-command = "nathanflurry.jj-workspace.new-tab"
-description = "new jj workspace (in tab)"
+command = "ezracerpac.jj-waltz.new-tab"
+description = "new jw workspace in tab"
 [[keys.command]]
 key = "prefix+d"
 type = "plugin_action"
-command = "nathanflurry.jj-workspace.remove"
-description = "remove jj workspace"
+command = "ezracerpac.jj-waltz.remove"
+description = "remove jw workspace"
+
+# herdr plugin install yuucu/herdr-hunk
+[[keys.command]]
+key = "prefix+p"
+type = "plugin_action"
+command = "yuucu.hunk.open-review"
+description = "Hunk review"
 
 [experimental]
 # Experimental local Kitty graphics rendering for attached clients.

--- a/herdr/plugins.json
+++ b/herdr/plugins.json
@@ -1,0 +1,439 @@
+[
+  {
+    "plugin_id": "ezracerpac.jj-waltz",
+    "name": "jj-waltz",
+    "version": "0.1.0",
+    "min_herdr_version": "0.7.0",
+    "description": "Create and remove jj-waltz workspaces from Herdr.",
+    "manifest_path": "/Users/brad.robinson/.config/herdr/plugins/github/ezracerpac.jj-waltz-1b3af96734b4/plugins/herdr/herdr-plugin.toml",
+    "plugin_root": "/Users/brad.robinson/.config/herdr/plugins/github/ezracerpac.jj-waltz-1b3af96734b4/plugins/herdr",
+    "enabled": true,
+    "platforms": [
+      "linux",
+      "macos"
+    ],
+    "build": [
+      {
+        "command": [
+          "sh",
+          "scripts/build.sh"
+        ]
+      }
+    ],
+    "actions": [
+      {
+        "id": "new",
+        "title": "New jw workspace",
+        "contexts": [
+          "workspace"
+        ],
+        "command": [
+          "./target/release/herdr-jj-waltz",
+          "open",
+          "workspace"
+        ]
+      },
+      {
+        "id": "new-tab",
+        "title": "New jw workspace in tab",
+        "contexts": [
+          "workspace"
+        ],
+        "command": [
+          "./target/release/herdr-jj-waltz",
+          "open",
+          "tab"
+        ]
+      },
+      {
+        "id": "remove",
+        "title": "Remove jw workspace",
+        "contexts": [
+          "workspace"
+        ],
+        "command": [
+          "./target/release/herdr-jj-waltz",
+          "open",
+          "remove"
+        ]
+      }
+    ],
+    "panes": [
+      {
+        "id": "create",
+        "title": "New jw workspace",
+        "placement": "overlay",
+        "command": [
+          "./target/release/herdr-jj-waltz",
+          "create"
+        ]
+      },
+      {
+        "id": "remove",
+        "title": "Remove jw workspace",
+        "placement": "overlay",
+        "command": [
+          "./target/release/herdr-jj-waltz",
+          "remove"
+        ]
+      }
+    ],
+    "source": {
+      "kind": "github",
+      "owner": "EzraCerpac",
+      "repo": "jj-waltz",
+      "subdir": "plugins/herdr",
+      "resolved_commit": "350ea473cd9150cf8b1ad19f19060c48045d3a03",
+      "managed_path": "/Users/brad.robinson/.config/herdr/plugins/github/ezracerpac.jj-waltz-1b3af96734b4",
+      "installed_unix_ms": 1786113841071
+    }
+  },
+  {
+    "plugin_id": "herdr-tab-title",
+    "name": "Herdr Tab Title",
+    "version": "0.1.0",
+    "min_herdr_version": "0.7.0",
+    "description": "Automatically formats Herdr tab titles.",
+    "manifest_path": "/Users/brad.robinson/.config/herdr/plugins/github/herdr-tab-title-7bbec35225f1/herdr-plugin.toml",
+    "plugin_root": "/Users/brad.robinson/.config/herdr/plugins/github/herdr-tab-title-7bbec35225f1",
+    "enabled": true,
+    "platforms": [
+      "linux",
+      "macos",
+      "windows"
+    ],
+    "build": [
+      {
+        "command": [
+          "cargo",
+          "build",
+          "--release"
+        ]
+      }
+    ],
+    "actions": [
+      {
+        "id": "refresh",
+        "title": "Refresh tab titles",
+        "contexts": [
+          "workspace"
+        ],
+        "command": [
+          "target/release/herdr-tab-title"
+        ]
+      }
+    ],
+    "events": [
+      {
+        "on": "tab.closed",
+        "command": [
+          "target/release/herdr-tab-title"
+        ]
+      },
+      {
+        "on": "tab.created",
+        "command": [
+          "target/release/herdr-tab-title"
+        ]
+      },
+      {
+        "on": "tab.focused",
+        "command": [
+          "target/release/herdr-tab-title"
+        ]
+      },
+      {
+        "on": "tab.renamed",
+        "command": [
+          "target/release/herdr-tab-title"
+        ]
+      },
+      {
+        "on": "workspace.closed",
+        "command": [
+          "target/release/herdr-tab-title"
+        ]
+      },
+      {
+        "on": "workspace.created",
+        "command": [
+          "target/release/herdr-tab-title"
+        ]
+      },
+      {
+        "on": "workspace.focused",
+        "command": [
+          "target/release/herdr-tab-title"
+        ]
+      },
+      {
+        "on": "workspace.renamed",
+        "command": [
+          "target/release/herdr-tab-title"
+        ]
+      }
+    ],
+    "source": {
+      "kind": "github",
+      "owner": "Newt6611",
+      "repo": "herdr-tab-title",
+      "resolved_commit": "a0827ebeec57d544bed005189a03b29e24be6a65",
+      "managed_path": "/Users/brad.robinson/.config/herdr/plugins/github/herdr-tab-title-7bbec35225f1",
+      "installed_unix_ms": 1783522044769
+    }
+  },
+  {
+    "plugin_id": "mroth.jj-status",
+    "name": "jj status",
+    "version": "0.1.1",
+    "min_herdr_version": "0.7.5",
+    "description": "Show the Jujutsu bookmark and status for jj workspaces in the spaces sidebar",
+    "manifest_path": "/Users/brad.robinson/.config/herdr/plugins/github/mroth.jj-status-f7e3ac54a4fe/herdr-plugin.toml",
+    "plugin_root": "/Users/brad.robinson/.config/herdr/plugins/github/mroth.jj-status-f7e3ac54a4fe",
+    "enabled": true,
+    "platforms": [
+      "macos",
+      "linux"
+    ],
+    "startup": [
+      {
+        "command": [
+          "bash",
+          "bin/refresh.sh"
+        ]
+      }
+    ],
+    "actions": [
+      {
+        "id": "refresh",
+        "title": "jj status: refresh all",
+        "contexts": [
+          "workspace"
+        ],
+        "command": [
+          "bash",
+          "bin/refresh.sh"
+        ]
+      }
+    ],
+    "events": [
+      {
+        "on": "workspace.created",
+        "command": [
+          "bash",
+          "bin/refresh.sh"
+        ]
+      },
+      {
+        "on": "workspace.focused",
+        "command": [
+          "bash",
+          "bin/refresh.sh"
+        ]
+      },
+      {
+        "on": "worktree.created",
+        "command": [
+          "bash",
+          "bin/refresh.sh"
+        ]
+      },
+      {
+        "on": "worktree.opened",
+        "command": [
+          "bash",
+          "bin/refresh.sh"
+        ]
+      }
+    ],
+    "source": {
+      "kind": "github",
+      "owner": "mroth",
+      "repo": "herdr-jj-status",
+      "resolved_commit": "40588ef743e1dd6a252b2e39765616584fd2e39e",
+      "managed_path": "/Users/brad.robinson/.config/herdr/plugins/github/mroth.jj-status-f7e3ac54a4fe",
+      "installed_unix_ms": 1786113541816
+    }
+  },
+  {
+    "plugin_id": "rjyo.window-title-sync",
+    "name": "Window Title Sync",
+    "version": "0.1.0",
+    "min_herdr_version": "0.7.0",
+    "description": "Sync the outer terminal title to the focused Herdr workspace, tab, and agent session.",
+    "manifest_path": "/Users/brad.robinson/.config/herdr/plugins/github/rjyo.window-title-sync-aa963fbbc3d9/herdr-plugin.toml",
+    "plugin_root": "/Users/brad.robinson/.config/herdr/plugins/github/rjyo.window-title-sync-aa963fbbc3d9",
+    "enabled": true,
+    "platforms": [
+      "macos",
+      "linux"
+    ],
+    "actions": [
+      {
+        "id": "refresh",
+        "title": "Refresh terminal title",
+        "contexts": [
+          "workspace",
+          "tab",
+          "pane"
+        ],
+        "command": [
+          "bun",
+          "sync-title.js"
+        ]
+      }
+    ],
+    "events": [
+      {
+        "on": "pane.agent_detected",
+        "command": [
+          "bun",
+          "sync-title.js"
+        ]
+      },
+      {
+        "on": "pane.agent_status_changed",
+        "command": [
+          "bun",
+          "sync-title.js"
+        ]
+      },
+      {
+        "on": "pane.closed",
+        "command": [
+          "bun",
+          "sync-title.js"
+        ]
+      },
+      {
+        "on": "pane.created",
+        "command": [
+          "bun",
+          "sync-title.js"
+        ]
+      },
+      {
+        "on": "pane.focused",
+        "command": [
+          "bun",
+          "sync-title.js"
+        ]
+      },
+      {
+        "on": "pane.moved",
+        "command": [
+          "bun",
+          "sync-title.js"
+        ]
+      },
+      {
+        "on": "tab.focused",
+        "command": [
+          "bun",
+          "sync-title.js"
+        ]
+      },
+      {
+        "on": "tab.renamed",
+        "command": [
+          "bun",
+          "sync-title.js"
+        ]
+      },
+      {
+        "on": "workspace.focused",
+        "command": [
+          "bun",
+          "sync-title.js"
+        ]
+      },
+      {
+        "on": "workspace.renamed",
+        "command": [
+          "bun",
+          "sync-title.js"
+        ]
+      },
+      {
+        "on": "workspace.updated",
+        "command": [
+          "bun",
+          "sync-title.js"
+        ]
+      }
+    ],
+    "source": {
+      "kind": "github",
+      "owner": "rjyo",
+      "repo": "herdr-window-title-sync",
+      "resolved_commit": "b07f1140b7308d66487b2f4be546c0c7db065569",
+      "managed_path": "/Users/brad.robinson/.config/herdr/plugins/github/rjyo.window-title-sync-aa963fbbc3d9",
+      "installed_unix_ms": 1782497782467
+    }
+  },
+  {
+    "plugin_id": "third774.last-workspace",
+    "name": "Last Workspace",
+    "version": "0.1.0",
+    "min_herdr_version": "0.7.0",
+    "description": "Toggle between the current and previously focused Herdr workspace.",
+    "manifest_path": "/Users/brad.robinson/.config/herdr/plugins/github/third774.last-workspace-5de7aeab3665/herdr-plugin.toml",
+    "plugin_root": "/Users/brad.robinson/.config/herdr/plugins/github/third774.last-workspace-5de7aeab3665",
+    "enabled": true,
+    "platforms": [
+      "linux",
+      "macos"
+    ],
+    "build": [
+      {
+        "platforms": [
+          "linux",
+          "macos"
+        ],
+        "command": [
+          "cargo",
+          "build",
+          "--release"
+        ]
+      }
+    ],
+    "actions": [
+      {
+        "id": "toggle",
+        "title": "Last workspace",
+        "contexts": [
+          "global",
+          "workspace"
+        ],
+        "command": [
+          "./target/release/herdr-last-workspace",
+          "toggle"
+        ]
+      }
+    ],
+    "events": [
+      {
+        "on": "workspace.closed",
+        "command": [
+          "./target/release/herdr-last-workspace",
+          "closed"
+        ]
+      },
+      {
+        "on": "workspace.focused",
+        "command": [
+          "./target/release/herdr-last-workspace",
+          "focused"
+        ]
+      }
+    ],
+    "source": {
+      "kind": "github",
+      "owner": "third774",
+      "repo": "herdr-last-workspace",
+      "resolved_commit": "8b55ebf15deaa52b49ff1c2500aab0c19c729420",
+      "managed_path": "/Users/brad.robinson/.config/herdr/plugins/github/third774.last-workspace-5de7aeab3665",
+      "installed_unix_ms": 1782497627354
+    }
+  }
+]

--- a/herdr/plugins/config/aarsh21.tab-title/config.toml
+++ b/herdr/plugins/config/aarsh21.tab-title/config.toml
@@ -1,0 +1,3 @@
+interval_seconds = 1
+directory_depth = 1
+show_tab_number = true

--- a/install.sh
+++ b/install.sh
@@ -95,11 +95,12 @@ curl -fsSL https://herdr.dev/install.sh | sh
 if command -v herdr >/dev/null 2>&1; then
   herdr integration install claude
   herdr integration install codex
-  herdr plugin install NathanFlurry/herdr-plugin-jj-workspace --yes
-  herdr plugin install rjyo/herdr-window-title-sync --yes
-  herdr plugin install third774/herdr-last-workspace --yes
-  herdr plugin install Newt6611/herdr-tab-title --yes
-  herdr plugin install yuucu/herdr-hunk --yes
+  herdr plugin install EzraCerpac/jj-waltz/plugins/herdr --yes # create/delete jj workspaces
+  herdr plugin install mroth/herdr-jj-status                   # Show JJ branch
+  herdr plugin install rjyo/herdr-window-title-sync --yes      # update term title to match location
+  herdr plugin install third774/herdr-last-workspace --yes     # Go to previous workspace
+  herdr plugin install aarsh21/herdr-tab-title                 # auto label tab by program
+  herdr plugin install yuucu/herdr-hunk --yes                  # Open hunk for review
 fi
 
 if uname -a | grep -q "WSL"; then

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -13,6 +13,7 @@ node = "latest"
 rust = "latest"
 ruby = "latest"
 usage = "latest"
+"github:agavra/tuicr" = "latest"
 
 # Dotfiles tasks — runnable from anywhere: `mise run stow`, `mise run skills`, ...
 # install.sh should shrink into these over time.


### PR DESCRIPTION

Swap jj-workspace plugin for jj-waltz (better integration with JJ workspace management) and replace NathanFlurry's plugin with EzraCerpac's version. Pulls tab-title plugin from aarsh21 instead of Newt6611, adds hunk review binding to the sidebar.

**Config Changes**
- UI sidebar: organize spaces into rows — state/workspace on top, branch/git status below, jj status indicators at bottom
- Plugin commands: update references from `nathanflurry.jj-workspace` to `ezracerpac.jj-waltz`; shorten descriptions to `jw` (jj-waltz)
- Hunk review binding: add `prefix+p` to launch review pane

**Plugin Registry**
- Generate plugins.json snapshot of installed plugins (jj-waltz, tab-title, jj-status, window-title-sync, last-workspace)
- Tab title config: poll every 1 second, show tab numbers, scan 1 directory deep

**Installation & Tools**
- Update install.sh to reflect new plugin sources and add clarity comments
- Install tuicr (TUI code review) as a mise tool

Ignore herdr runtime state files (session.json, release-notes.json, session-history.json) in .gitignore.
