### PR TITLE
docs: simplify jj stacked-PR workflow description

### DIFF
--- a/docs/workflow.html
+++ b/docs/workflow.html
@@ -68,7 +68,7 @@
 <ul>
   <li>~55 jj aliases: <code>jj tug</code> to move bookmarks, revset aliases like <code>ghbranch</code>, a deliberate split between bare <code>jj</code> (clean log) and <code>jj log</code> (broad leaves view)</li>
   <li>hunk as pager and interactive diff review; agents drive it through <code>hunk session</code> commands against the live daemon</li>
-  <li>lazyjj (local build) for stacked-PR management; <code>ghpr</code>/<code>ghprs</code> fish functions push bookmarks into PRs</li>
+  <li>locally maintained jj aliases for stacked-PR management; <code>ghpr</code>/<code>ghprs</code> fish functions push bookmarks into PRs</li>
   <li>SSH commit signing with stock <code>ssh-keygen</code> against on-disk keys; 1Password machines override via gitignored <code>~/.gitlocal</code> / jj <code>conf.d/z-local.toml</code></li>
   <li><code>sesh</code> startup commands run <code>jj pull</code> on session attach, so projects stay fresh without thinking about it</li>
 </ul>

--- a/fish/functions/ghprs.fish
+++ b/fish/functions/ghprs.fish
@@ -2,13 +2,11 @@
 # bookmark bottom-to-top. Reuses ghpr for each PR (AI title/body, auto base
 # detection, existing-PR skip). jj-only — in git repos just use ghpr.
 #
-# Flags:
-#   -d/--draft, -l/--label  → applied to every PR in the stack
+# All ghpr flags are forwarded to every PR in the stack, except:
 #   -B/--base <ref>         → base for the BOTTOM PR only; the rest stack on
 #                             their parent bookmark as usual
-#   --dry-run               → preview every PR, create nothing
-# -t/--title and -r/--revision are rejected: they're per-PR and would clobber
-# the whole stack (title should be AI-generated per PR; -r conflicts with -b).
+# -t/--title, -r/--revision, and -b/--bookmark are rejected: they're per-PR and
+# would clobber the whole stack (title should be AI-generated per PR).
 
 function ghprs --description "Create stacked GitHub PRs with AI bodies via ghpr"
     if not type -q jj; or not jj workspace root >/dev/null 2>&1
@@ -16,13 +14,46 @@ function ghprs --description "Create stacked GitHub PRs with AI bodies via ghpr"
         return 1
     end
 
-    argparse d/draft dry-run 'B/base=' 't/title=' 'b/bookmark=' 'r/revision=' 'l/label=' -- $argv
-    or return 1
-
-    if set -q _flag_title; or set -q _flag_revision; or set -q _flag_bookmark
-        echo "Error: -t/--title, -r/--revision, -b/--bookmark are per-PR and break a stack."
-        echo "  Titles are AI-generated per PR. Base the bottom PR with -B; the rest auto-stack."
-        return 1
+    set -l common
+    set -l bottom_base
+    set -l has_bottom_base false
+    set -l i 1
+    while test $i -le (count $argv)
+        set -l arg $argv[$i]
+        switch $arg
+            case --
+                set -a common $argv[$i..-1]
+                break
+            case -t --title -b --bookmark -r --revision '-t?*' '--title=*' '-b?*' '--bookmark=*' '-r?*' '--revision=*'
+                echo "Error: -t/--title, -r/--revision, -b/--bookmark are per-PR and break a stack."
+                echo "  Titles are AI-generated per PR. Base the bottom PR with -B; the rest auto-stack."
+                return 1
+            case -B --base
+                if test $i -eq (count $argv)
+                    echo "Error: $arg requires a value."
+                    return 1
+                end
+                set i (math $i + 1)
+                set bottom_base $argv[$i]
+                set has_bottom_base true
+            case '-B?*'
+                set bottom_base (string sub --start 3 -- $arg)
+                set has_bottom_base true
+            case '--base=*'
+                set bottom_base (string replace --regex '^--base=' '' -- $arg)
+                set has_bottom_base true
+            case -l --label
+                set -a common $arg
+                if test $i -eq (count $argv)
+                    echo "Error: $arg requires a value."
+                    return 1
+                end
+                set i (math $i + 1)
+                set -a common $argv[$i]
+            case '*'
+                set -a common $arg
+        end
+        set i (math $i + 1)
     end
 
     # ghpr requires bookmarks already on origin — push the whole stack first
@@ -42,12 +73,6 @@ function ghprs --description "Create stacked GitHub PRs with AI bodies via ghpr"
         return 1
     end
 
-    # Flags that apply to every PR
-    set -l common
-    set -q _flag_draft; and set -a common --draft
-    set -q _flag_dry_run; and set -a common --dry-run
-    set -q _flag_label; and set -a common --label $_flag_label
-
     echo "✓ "(count $bookmarks)" bookmark(s) in stack"
     for i in (seq (count $bookmarks))
         set -l bm $bookmarks[$i]
@@ -55,8 +80,8 @@ function ghprs --description "Create stacked GitHub PRs with AI bodies via ghpr"
         echo "━━━ PR for $bm ━━━"
         set -l args -b $bm $common
         # -B overrides the bottom PR's base only; upper PRs auto-detect parent
-        if test $i -eq 1; and set -q _flag_base
-            set args $args -B $_flag_base
+        if test $i -eq 1; and test "$has_bottom_base" = true
+            set args $args -B $bottom_base
         end
         ghpr $args
     end


### PR DESCRIPTION
Replaced reference to lazyjj (external tool) with locally maintained jj aliases, which better reflects the actual setup. The aliases handle stacked-PR management via `ghpr`/`ghprs` fish functions.
